### PR TITLE
fixed beamlattice bug where only r2 writes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project (lib3MF)
 # Define Version
 set(LIB3MF_VERSION_MAJOR 1)				# increase on every backward-compatibility breaking change of the API
 set(LIB3MF_VERSION_MINOR 0)				# increase on every backward compatible change of the API
-set(LIB3MF_VERSION_MICRO 0)				# increase on on every change that does not alter the API
+set(LIB3MF_VERSION_MICRO 1)				# increase on on every change that does not alter the API
 
 set(NMR_COM_NATIVE FALSE) # by default, do not actually implement a COM interface
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
@@ -622,11 +622,17 @@ namespace NMR {
 			const std::string sR1 = fnUTF16toUTF8(L"\" " + std::wstring(XML_3MF_ATTRIBUTE_BEAMLATTICE_R1) + L"=\"");
 			putBeamString(sR1.c_str());
 			putBeamDouble(pBeam->m_radius[0]);
-			// if the string representation of r1 is different to that of m_radius[0]
+			// if the string representation of r2 is different to that of m_radius[0]
 			bWriteR1 = fabs(pBeam->m_radius[0] - pBeam->m_radius[1]) * m_snPutDoubleFactor > 0.1;
 		}
+		//if the string representation of r2 is different to that of m_radius[0]
+		else if (fabs(pBeam->m_radius[0] - pBeam->m_radius[1]) * m_snPutDoubleFactor > 0.1) {
+			const std::string sR1 = fnUTF16toUTF8(L"\" " + std::wstring(XML_3MF_ATTRIBUTE_BEAMLATTICE_R1) + L"=\"");
+			putBeamString(sR1.c_str());
+			putBeamDouble(pBeam->m_radius[0]);
+		}
 		else {
-			// if the string representation of r1 is different to that of dRadius
+			// if the string representation of r2 is different to that of dRadius
 			bWriteR1 = fabs(dRadius - pBeam->m_radius[1]) * m_snPutDoubleFactor > 0.1;
 		}
 		if (bWriteR1) {

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
@@ -608,6 +608,10 @@ namespace NMR {
 	}
 
 
+	bool stringRepresentationsDiffer(double a, double b, double putFactor) {
+		return  fabs(a - b) * putFactor > 0.1;
+	}
+
 	__NMR_INLINE void CModelWriterNode100_Mesh::writeBeamData(_In_ MESHBEAM * pBeam, _In_ nfDouble dRadius, _In_ eModelBeamLatticeCapMode eDefaultCapMode)
 	{
 		__NMRASSERT(pBeam);
@@ -616,26 +620,15 @@ namespace NMR {
 		const std::string sV2 = fnUTF16toUTF8(L"\" " + std::wstring(XML_3MF_ATTRIBUTE_BEAMLATTICE_V2) + L"=\"");
 		putBeamString(sV2.c_str());
 		putBeamUInt32(pBeam->m_nodeindices[1]);
-		nfBool bWriteR1 = true;
-		// if the string representation of r1 is different from that of dRadius
-		if (fabs(dRadius - pBeam->m_radius[0]) * m_snPutDoubleFactor > 0.1) {
-			const std::string sR1 = fnUTF16toUTF8(L"\" " + std::wstring(XML_3MF_ATTRIBUTE_BEAMLATTICE_R1) + L"=\"");
-			putBeamString(sR1.c_str());
-			putBeamDouble(pBeam->m_radius[0]);
-			// if the string representation of r2 is different to that of m_radius[0]
-			bWriteR1 = fabs(pBeam->m_radius[0] - pBeam->m_radius[1]) * m_snPutDoubleFactor > 0.1;
-		}
-		//if the string representation of r2 is different to that of m_radius[0]
-		else if (fabs(pBeam->m_radius[0] - pBeam->m_radius[1]) * m_snPutDoubleFactor > 0.1) {
-			const std::string sR1 = fnUTF16toUTF8(L"\" " + std::wstring(XML_3MF_ATTRIBUTE_BEAMLATTICE_R1) + L"=\"");
-			putBeamString(sR1.c_str());
-			putBeamDouble(pBeam->m_radius[0]);
-		}
-		else {
-			// if the string representation of r2 is different to that of dRadius
-			bWriteR1 = fabs(dRadius - pBeam->m_radius[1]) * m_snPutDoubleFactor > 0.1;
-		}
+
+		nfBool bWriteR2 = stringRepresentationsDiffer(pBeam->m_radius[0], pBeam->m_radius[1], m_snPutDoubleFactor);
+		nfBool bWriteR1 = bWriteR2 || stringRepresentationsDiffer(pBeam->m_radius[0], dRadius, m_snPutDoubleFactor);
 		if (bWriteR1) {
+			const std::string sR1 = fnUTF16toUTF8(L"\" " + std::wstring(XML_3MF_ATTRIBUTE_BEAMLATTICE_R1) + L"=\"");
+			putBeamString(sR1.c_str());
+			putBeamDouble(pBeam->m_radius[0]);
+		}
+		if (bWriteR2) {
 			const std::string sR2 = fnUTF16toUTF8(L"\" " + std::wstring(XML_3MF_ATTRIBUTE_BEAMLATTICE_R2) + L"=\"");
 			putBeamString(sR2.c_str());
 			putBeamDouble(pBeam->m_radius[1]);

--- a/Source/UnitTests/UnitTest_BeamLattice.cpp
+++ b/Source/UnitTests/UnitTest_BeamLattice.cpp
@@ -323,6 +323,77 @@ void WriteBeamLattice_Negative()
 	ASSERT_NE(lib3mf_meshobject_addbeam(pMeshObject.get(), &beam, NULL), S_OK) << L"Could add beam to model of type support";
 }
 
+void WriteBeamLattice_Positive()
+{
+	using namespace NMR;
+	CustomLib3MFBase pModel;
+
+	// Create Model Instance
+	ASSERT_EQ(NMR::lib3mf_createmodel(&pModel.get()), S_OK) << L"Could not create model";
+
+	CustomLib3MFBase pMeshObject;
+	ASSERT_EQ(lib3mf_model_addmeshobject(pModel.get(), &pMeshObject.get()), S_OK) << L"Could not add mesh object";
+
+	MODELMESHVERTEX vert;
+	vert.m_fPosition[0] = 0;
+	vert.m_fPosition[1] = 0;
+	vert.m_fPosition[2] = 0;
+	ASSERT_EQ(lib3mf_meshobject_addvertex(pMeshObject.get(), &vert, NULL), S_OK) << L"Could not add vertex";
+	vert.m_fPosition[0] = 1;
+	vert.m_fPosition[1] = 1;
+	vert.m_fPosition[2] = 1;
+	ASSERT_EQ(lib3mf_meshobject_addvertex(pMeshObject.get(), &vert, NULL), S_OK) << L"Could not add vertex";
+	vert.m_fPosition[0] = 2;
+	vert.m_fPosition[1] = 2;
+	vert.m_fPosition[2] = 2;
+	ASSERT_EQ(lib3mf_meshobject_addvertex(pMeshObject.get(), &vert, NULL), S_OK) << L"Could not add vertex";
+	vert.m_fPosition[0] = 3;
+	vert.m_fPosition[1] = 3;
+	vert.m_fPosition[2] = 3;
+	ASSERT_EQ(lib3mf_meshobject_addvertex(pMeshObject.get(), &vert, NULL), S_OK) << L"Could not add vertex";
+	vert.m_fPosition[0] = 4;
+	vert.m_fPosition[1] = 4;
+	vert.m_fPosition[2] = 4;
+	ASSERT_EQ(lib3mf_meshobject_addvertex(pMeshObject.get(), &vert, NULL), S_OK) << L"Could not add vertex";
+
+	MODELMESHBEAM beam;
+	beam.m_nIndices[0] = 0;
+	beam.m_nIndices[1] = 1;
+	beam.m_dRadius[0] = 0.1;
+	beam.m_dRadius[1] = 0.1;
+	ASSERT_EQ(lib3mf_meshobject_addbeam(pMeshObject.get(), &beam, NULL), S_OK) << L"Could not add beam.";
+	ASSERT_EQ(lib3mf_meshobject_setbeamlattice_radius(pMeshObject.get(), 0.1), S_OK) << L"Could not set default radius.";
+
+	beam.m_nIndices[0] = 1;
+	beam.m_nIndices[1] = 2;
+	beam.m_dRadius[0] = 0.2;
+	beam.m_dRadius[1] = 0.1;
+	ASSERT_EQ(lib3mf_meshobject_addbeam(pMeshObject.get(), &beam, NULL), S_OK) << L"Could not add beam.";
+
+	beam.m_nIndices[0] = 2;
+	beam.m_nIndices[1] = 3;
+	beam.m_dRadius[0] = 0.1;
+	beam.m_dRadius[1] = 0.2;
+	ASSERT_EQ(lib3mf_meshobject_addbeam(pMeshObject.get(), &beam, NULL), S_OK) << L"Could not add beam.";
+
+	beam.m_nIndices[0] = 3;
+	beam.m_nIndices[1] = 4;
+	beam.m_dRadius[0] = 0.2;
+	beam.m_dRadius[1] = 0.2;
+	ASSERT_EQ(lib3mf_meshobject_addbeam(pMeshObject.get(), &beam, NULL), S_OK) << L"Could not add beam.";
+
+	beam.m_nIndices[0] = 4;
+	beam.m_nIndices[1] = 0;
+	beam.m_dRadius[0] = 0.2;
+	beam.m_dRadius[1] = 0.3;
+	ASSERT_EQ(lib3mf_meshobject_addbeam(pMeshObject.get(), &beam, NULL), S_OK) << L"Could not add beam.";
+
+	CustomLib3MFBase p3MFWriter;
+	EXPECT_EQ(lib3mf_model_querywriter(pModel.get(), "3mf", &p3MFWriter.get()), S_OK) << L"Could not create modelwriter";
+
+	EXPECT_EQ(lib3mf_writer_writetofileutf8(p3MFWriter.get(), (std::string("TestOutput") + separator() + "beamlattice_default.3mf").c_str()), S_OK) << L"Could not write file";
+}
+
 TEST(BeamLattice, ReadBoxSimple)
 {
 	Box_Simple();
@@ -361,4 +432,8 @@ TEST(BeamLattice, WriteBeamLattice_Negative)
 	WriteBeamLattice_Negative();
 }
 
+TEST(BeamLattice, WriteBeamLattice_Positive)
+{
+	WriteBeamLattice_Positive();
+}
 


### PR DESCRIPTION
If r1 and r2 are different, but r1 matches the default radius, it will only write r2, which is against spec.
Just added a condition where if r1 matches the default and r1 and r2 are different, write r1.