### PR TITLE
MinGW win32 build / MXE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ else()
 	./Source/Common/OPC/NMR_OpcPackageRelationshipReader.cpp
 	./Source/Common/OPC/NMR_OpcPackageContentTypesReader.cpp
 	./Source/Common/Platform/NMR_ImportStream_GCC_Native.cpp
+	./Source/Common/Platform/NMR_ImportStream_GCC_Win32.cpp
 	./Source/Common/Platform/NMR_ImportStream_ZIP.cpp
 	./Source/Common/Platform/NMR_ExportStream_GCC_Native.cpp
 	./Source/Common/Platform/NMR_ExportStream_GCC_Win32.cpp

--- a/Include/Common/NMR_ErrorConst.h
+++ b/Include/Common/NMR_ErrorConst.h
@@ -262,6 +262,9 @@ NMR_ErrorConst.h defines all error code constants.
 // Attachment has an empty stream
 #define NMR_ERROR_IMPORTSTREAMISEMPTY 0x1048
 
+// UUID generation failed
+#define NMR_ERROR_UUIDGENERATIONFAILED 0x1049
+
 /*-------------------------------------------------------------------
 Core framework error codes (0x2XXX)
 -------------------------------------------------------------------*/

--- a/Source/Common/NMR_Exception.cpp
+++ b/Source/Common/NMR_Exception.cpp
@@ -121,6 +121,7 @@ namespace NMR {
 		case NMR_ERROR_OPC_DUPLICATE_RELATIONSHIP_ID: return "Document contains a duplicate relationship ID.";
 		case NMR_ERROR_INVALIDRELATIONSHIPTYPEFORTEXTURE: return "A texture must use a OPC part with relationshiptype 3D Texture.";
 		case NMR_ERROR_IMPORTSTREAMISEMPTY: return "An attachment to be read does coes not have any content.";
+		case NMR_ERROR_UUIDGENERATIONFAILED: return "Generation of a UUID failed.";
 
 
 		// Unhandled exception

--- a/Source/Common/NMR_UUID.cpp
+++ b/Source/Common/NMR_UUID.cpp
@@ -37,13 +37,16 @@ NMR_UUID.cpp implements a datatype and functions to handle UUIDs
 
 #include <algorithm>
 #include <random>
+#include <ctime>
 
 namespace NMR
 {
 	CUUID::CUUID()
 	{
+		static std::random_device rd;
+
 		std::mt19937 rng;
-		rng.seed(std::random_device()());
+		rng.seed(rd() ^ time(nullptr));
 		std::uniform_int_distribution<std::mt19937::result_type> distHexaDec(0, 15);
 		const nfWChar* hexaDec = L"0123456789abcdef";
 		nfWChar string[33];

--- a/Source/Common/NMR_UUID.cpp
+++ b/Source/Common/NMR_UUID.cpp
@@ -36,17 +36,29 @@ NMR_UUID.cpp implements a datatype and functions to handle UUIDs
 #include "Common/NMR_Exception.h"
 
 #include <algorithm>
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+#include <Objbase.h>
+#include <iomanip>
+#else
 #include <random>
-#include <ctime>
+#include "Common/Platform/NMR_Time.h"
+#endif
 
 namespace NMR
 {
 	CUUID::CUUID()
 	{
-		static std::random_device rd;
-
-		std::mt19937 rng;
-		rng.seed(rd() ^ time(nullptr));
+#if defined(_WIN32) && !defined(__MINGW32__)
+		GUID guid;
+		if (CoCreateGuid(&guid) != S_OK)
+			throw CNMRException(NMR_ERROR_UUIDGENERATIONFAILED);
+		LPOLESTR str;
+		if (StringFromCLSID(guid, &str) != S_OK)
+			throw CNMRException(NMR_ERROR_UUIDGENERATIONFAILED);
+		set(str);
+#else
+		static std::mt19937 rng(((unsigned int)std::random_device()()) ^ ((unsigned int)fnGetUnixTime()) );
 		std::uniform_int_distribution<std::mt19937::result_type> distHexaDec(0, 15);
 		const nfWChar* hexaDec = L"0123456789abcdef";
 		nfWChar string[33];
@@ -54,6 +66,7 @@ namespace NMR
 			string[i] = hexaDec[distHexaDec(rng)];
 		string[32] = 0;
 		set(string);
+#endif
 	}
 
 	CUUID::CUUID(const nfWChar* pString)

--- a/Source/Common/Platform/NMR_ExportStream_GCC_Native.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_GCC_Native.cpp
@@ -49,7 +49,7 @@ namespace NMR {
 			throw CNMRException(NMR_ERROR_INVALIDPARAM);
 
 		std::wstring sFileName(pwszFileName);
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 		m_Stream.open(sFileName.c_str(), std::ios::out | std::ios::binary);
 #else
 		std::string sUTF8Name = fnUTF16toUTF8(sFileName);

--- a/Source/Common/Platform/NMR_ImportStream_GCC_Native.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_GCC_Native.cpp
@@ -47,7 +47,7 @@ namespace NMR {
 			throw CNMRException(NMR_ERROR_INVALIDPARAM);
 
 		std::wstring sFileName(pwszFileName);
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__MINGW32__)
 		m_Stream.open(sFileName.c_str(), std::ios::in | std::ios::binary);
 #else
 		std::string sUTF8Name = fnUTF16toUTF8(sFileName);

--- a/Source/Common/Platform/NMR_Time.cpp
+++ b/Source/Common/Platform/NMR_Time.cpp
@@ -41,11 +41,11 @@ namespace NMR {
 
 	nfTimeStamp fnGetUnixTime()
 	{
-    #ifdef _WIN32
+    #if defined(_WIN32) && !defined(__MINGW32__)
 		return _time64(nullptr);
     #else
-        return time(nullptr);
-    #endif // _WIN32
+        	return time(nullptr);
+    #endif
 	}
 
 }

--- a/Source/Main/dllmain.cpp
+++ b/Source/Main/dllmain.cpp
@@ -31,7 +31,7 @@ dllmain.cpp : Defines the entry point for the DLL application.
 
 --*/
 
-#include <Windows.h>
+#include <windows.h>
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {


### PR DESCRIPTION
This pull request is initial work to get lib3MF building on MinGW. Specifically this would enable use of lib3MF in OpenSCAD for Windows which is using the MXE build environment.

The changes from this pull request allow building of the library, but there's still issues open, so this is also a __request for help__ to track down the remaining issues.

Changes so far:
- Use lower case windows.h which should be compatible with all platforms
- Add missing GCC-Win32 file to CMakeLists.txt
- Don't use `wchar_t` in `open()` calls in the native stream handlers

Open issues:
- Still producing `liblib3MF` file name, even with the proposed fix in #34 
- Errors when generating 3MF file in `lib3mf_model_addmeshobject()` with `A UUID is not unique within a package. (000080ad)`
- It would help to be able to generate static builds, e.g. by implementing a build flag like `LIB3MF_BUILD_TYPE=STATIC`