### PR TITLE
Add warning when reading multiproperties

### DIFF
--- a/Include/Model/Classes/NMR_ModelConstants.h
+++ b/Include/Model/Classes/NMR_ModelConstants.h
@@ -192,6 +192,9 @@ These are given by the 3MF Standard
 #define XML_3MF_ELEMENT_COMPOSITE                   L"composite"
 #define XML_3MF_ATTRIBUTE_COMPOSITE_VALUES          L"values"
 
+// Multiproperties (not implemented!)
+#define XML_3MF_ELEMENT_MULTIPROPERTIES             L"multiproperties"
+
 // Geometry element.
 #define XML_3MF_ELEMENT_GEOMETRY                    L"geometry"
 #define XML_3MF_ATTRIBUTE_GEOMETRY_DATA             L"data"

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Resources.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Resources.cpp
@@ -109,8 +109,9 @@ namespace NMR {
 				PModelReaderNode pXMLNode = std::make_shared<CModelReaderNode100_Texture2D>(m_pModel, m_pWarnings);
 				pXMLNode->parseXML(pXMLReader);
 			}
-			else if (wcscmp(pChildName, XML_3MF_ELEMENT_COMPOSITEMATERIALS) == 0) {
-				// Compositematerials are not implemented in lib3mf.
+			else if ( (wcscmp(pChildName, XML_3MF_ELEMENT_COMPOSITEMATERIALS) == 0) ||
+				(wcscmp(pChildName, XML_3MF_ELEMENT_MULTIPROPERTIES) == 0) ) {
+				// Compositematerials and multiproperties are not implemented in lib3mf.
 				// signal this to the user via a warning
 				m_pWarnings->addException(CNMRException(NMR_ERROR_NAMESPACE_INVALID_ELEMENT), mrwInvalidOptionalValue);
 			}

--- a/Source/UnitTests/UnitTest_Thumbnails.cpp
+++ b/Source/UnitTests/UnitTest_Thumbnails.cpp
@@ -254,7 +254,7 @@ namespace NMR {
 
 	TEST(Thumbnails, ObjectThumbnail_Read)
 	{
-		LoadFileWithObjectThumbnail(sTestFilesPath + separator() + "Mixed" + separator(), "texcube.3mf", 1);
+		LoadFileWithObjectThumbnail(sTestFilesPath + separator() + "Mixed" + separator(), "texcube.3mf", 2);
 	}
 
 	TEST(Thumbnails, ObjectThumbnail_ReadWrite)


### PR DESCRIPTION
as they are not implemented.