### PR TITLE
Using public URL for googletest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googletest"]
 	path = UnitTests/googletest
-	url = git@github.com:google/googletest.git
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
Use public URL instead of SSH URL to avoid authentication errors when pulling from googltest.

See this for more details.  https://salferrarello.com/git-submodule-fatal-read-remote-repository/