### PR TITLE
Fix compiler warnings for VS Win32 build

### DIFF
--- a/Source/Common/Platform/NMR_ExportStream_Memory.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_Memory.cpp
@@ -70,10 +70,10 @@ namespace NMR {
 	nfUint64 CExportStreamMemory::writeBuffer(_In_ const void * pBuffer, _In_ nfUint64 cbTotalBytesToWrite) {
 		nfByte *pByteBuffer = (nfByte *)pBuffer;
 		if ((m_Position + cbTotalBytesToWrite) > m_Buffer.size()) {
-			m_Buffer.resize(m_Position + cbTotalBytesToWrite);
+			m_Buffer.resize(static_cast<size_t>(m_Position + cbTotalBytesToWrite));
 		}
 		for (nfUint64 i = 0; i < cbTotalBytesToWrite; i++) {
-			m_Buffer[m_Position + i] = pByteBuffer[i];
+			m_Buffer[static_cast<size_t>(m_Position + i)] = pByteBuffer[i];
 		}
 		m_Position += cbTotalBytesToWrite;
 		return cbTotalBytesToWrite;

--- a/Source/Common/Platform/NMR_XmlReader_Native.cpp
+++ b/Source/Common/Platform/NMR_XmlReader_Native.cpp
@@ -924,23 +924,23 @@ namespace NMR {
 				if (pAmp != nullptr) {
 					pColon = pIterChar;
 					long long compareLen = pColon - pAmp + 1;
-					if (wcsncmp(pAmp, L"&quot;", std::min((long long)(6), compareLen)) == 0) {
+					if (wcsncmp(pAmp, L"&quot;", static_cast<size_t>(std::min((long long)(6), compareLen))) == 0) {
 						*pWriteChar = L'\"';
 						pWriteChar++;
 					}
-					else if (wcsncmp(pAmp, L"&apos;", std::min((long long)(6), compareLen)) == 0) {
+					else if (wcsncmp(pAmp, L"&apos;", static_cast<size_t>(std::min((long long)(6), compareLen))) == 0) {
 						*pWriteChar = L'\'';
 						pWriteChar++;
 					}
-					else if (wcsncmp(pAmp, L"&lt;", std::min((long long)(4), compareLen)) == 0) {
+					else if (wcsncmp(pAmp, L"&lt;", static_cast<size_t>(std::min((long long)(4), compareLen))) == 0) {
 						*pWriteChar = L'<';
 						pWriteChar++;
 					}
-					else if (wcsncmp(pAmp, L"&gt;", std::min((long long)(4), compareLen)) == 0) {
+					else if (wcsncmp(pAmp, L"&gt;", static_cast<size_t>(std::min((long long)(4), compareLen))) == 0) {
 						*pWriteChar = L'>';
 						pWriteChar++;
 					}
-					else if (wcsncmp(pAmp, L"&amp;", std::min((long long)(5), compareLen)) == 0) {
+					else if (wcsncmp(pAmp, L"&amp;", static_cast<size_t>(std::min((long long)(5), compareLen))) == 0) {
 						*pWriteChar = L'&';
 						pWriteChar++;
 					}

--- a/Source/Libraries/libzip/zip_buffer.c
+++ b/Source/Libraries/libzip/zip_buffer.c
@@ -148,7 +148,7 @@ _zip_buffer_new(zip_uint8_t *data, zip_uint64_t size)
     zip_buffer_t *buffer;
     
     if (data == NULL) {
-        if ((data = (zip_uint8_t *)malloc(size)) == NULL) {
+        if ((data = (zip_uint8_t *)malloc((size_t)size)) == NULL) {
             return NULL;
         }
     }

--- a/Source/Libraries/libzip/zip_close.c
+++ b/Source/Libraries/libzip/zip_close.c
@@ -399,7 +399,7 @@ copy_data(zip_t *za, zip_uint64_t len)
     size_t n;
 
     while (len > 0) {
-	n = len > sizeof(buf) ? sizeof(buf) : len;
+	n = len > sizeof(buf) ? sizeof(buf) : (size_t)(len);
 	if (_zip_read(za->src, buf, n, &za->error) < 0) {
 	    return -1;
 	}

--- a/Source/Libraries/libzip/zip_error_to_str.c
+++ b/Source/Libraries/libzip/zip_error_to_str.c
@@ -47,7 +47,7 @@ zip_error_to_str(char *buf, zip_uint64_t len, int ze, int se)
     const char *zs, *ss;
 
     if (ze < 0 || ze >= _zip_nerr_str)
-	return snprintf(buf, len, "Unknown error %d", ze);
+	return snprintf(buf, (size_t)len, "Unknown error %d", ze);
 
     zs = _zip_err_str[ze];
 	
@@ -64,6 +64,6 @@ zip_error_to_str(char *buf, zip_uint64_t len, int ze, int se)
 	ss = NULL;
     }
 
-    return snprintf(buf, len, "%s%s%s",
+    return snprintf(buf, (size_t)len, "%s%s%s",
 		    zs, (ss ? ": " : ""), (ss ? ss : ""));
 }

--- a/Source/Libraries/libzip/zip_open.c
+++ b/Source/Libraries/libzip/zip_open.c
@@ -584,7 +584,7 @@ _zip_find_central_dir(zip_t *za, zip_uint64_t len)
     zip_error_set(&error, ZIP_ER_NOZIP, 0);
 
     match = _zip_buffer_get(buffer, 0);
-    while ((match=_zip_memmem(match, _zip_buffer_left(buffer)-(EOCDLEN-4), (const unsigned char *)EOCD_MAGIC, 4)) != NULL) {
+    while ((match=_zip_memmem(match, (size_t)_zip_buffer_left(buffer)-(EOCDLEN-4), (const unsigned char *)EOCD_MAGIC, 4)) != NULL) {
         _zip_buffer_set_offset(buffer, (zip_uint64_t)(match - _zip_buffer_data(buffer)));
         if ((cdirnew = _zip_read_cdir(za, buffer, (zip_uint64_t)buf_offset, &error)) != NULL) {
             if (cdir) {

--- a/Source/Libraries/libzip/zip_source_buffer.c
+++ b/Source/Libraries/libzip/zip_source_buffer.c
@@ -346,7 +346,7 @@ buffer_read(buffer_t *buffer, zip_uint8_t *data, zip_uint64_t length)
     while (n < length) {
 	zip_uint64_t left = ZIP_MIN(length - n, buffer->fragment_size - fragment_offset);
 	
-	memcpy(data + n, buffer->fragments[i] + fragment_offset, left);
+	memcpy(data + n, buffer->fragments[i] + fragment_offset, (size_t)left);
 
 	n += left;
 	i++;
@@ -393,7 +393,7 @@ buffer_write(buffer_t *buffer, const zip_uint8_t *data, zip_uint64_t length, zip
 		new_capacity *= 2;
 	    }
 
-	    zip_uint8_t **fragments = realloc(buffer->fragments, new_capacity * sizeof(*fragments));
+	    zip_uint8_t **fragments = realloc(buffer->fragments, (size_t)new_capacity * sizeof(*fragments));
 
 	    if (fragments == NULL) {
 		zip_error_set(error, ZIP_ER_MEMORY, 0);
@@ -405,7 +405,7 @@ buffer_write(buffer_t *buffer, const zip_uint8_t *data, zip_uint64_t length, zip
 	}
 
 	while (buffer->nfragments < needed_fragments) {
-	    if ((buffer->fragments[buffer->nfragments] = malloc(buffer->fragment_size)) == NULL) {
+	    if ((buffer->fragments[buffer->nfragments] = malloc((size_t)buffer->fragment_size)) == NULL) {
 		zip_error_set(error, ZIP_ER_MEMORY, 0);
 		return -1;
 	    }
@@ -419,7 +419,7 @@ buffer_write(buffer_t *buffer, const zip_uint8_t *data, zip_uint64_t length, zip
     while (n < length) {
 	zip_uint64_t left = ZIP_MIN(length - n, buffer->fragment_size - fragment_offset);
 		
-	memcpy(buffer->fragments[i] + fragment_offset, data + n, left);
+	memcpy(buffer->fragments[i] + fragment_offset, data + n, (size_t)left);
 
 	n += left;
 	i++;

--- a/Source/Libraries/libzip/zip_source_deflate.c
+++ b/Source/Libraries/libzip/zip_source_deflate.c
@@ -121,7 +121,7 @@ compress_read(zip_source_t *src, struct deflate *ctx, void *data, zip_uint64_t l
             if (ctx->can_store && ctx->zstr.total_in <= ctx->zstr.total_out) {
                 ctx->is_stored = true;
                 ctx->size = ctx->zstr.total_in;
-                memcpy(data, ctx->buffer, ctx->size);
+                memcpy(data, ctx->buffer, (size_t)ctx->size);
                 return (zip_int64_t)ctx->size;
             }
             /* fallthrough */

--- a/Source/Model/COM/NMR_COMInterface_ModelWriter.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelWriter.cpp
@@ -213,7 +213,7 @@ namespace NMR {
 				throw CNMRException(NMR_ERROR_INSUFFICIENTBUFFERSIZE);
 
 			// TODO eliminate this copy, perhaps by allowing CExportStreamMemory to use existing buffers
-			memcpy(pBuffer, pStream->getData(), cbStreamSize);
+			memcpy(pBuffer, pStream->getData(), static_cast<size_t>(cbStreamSize));
 
 			return handleSuccess();
 		}

--- a/UnitTests/Source/UnitTest_Attachments.cpp
+++ b/UnitTests/Source/UnitTest_Attachments.cpp
@@ -127,7 +127,7 @@ namespace NMR {
 					
 				// get surface regions as xml
 				std::string strAttachmentPayload;
-				strAttachmentPayload.resize(cbStreamSize);
+				strAttachmentPayload.resize(static_cast<size_t>(cbStreamSize));
 				ASSERT_EQ(NMR::lib3mf_attachment_writetobuffer(pAttachment.get(), (BYTE *)&strAttachmentPayload[0], cbStreamSize), S_OK)
 					<< L"could not write model attachment to buffer";
 

--- a/UnitTests/Source/UnitTest_ReadWrite.cpp
+++ b/UnitTests/Source/UnitTest_ReadWrite.cpp
@@ -510,7 +510,7 @@ namespace NMR {
 		std::streamsize size = file.tellg();
 		file.seekg(0, std::ios::beg);
 		// Memory buffer
-		std::vector<char> buffer(size);
+		std::vector<char> buffer(static_cast<size_t>(size));
 		EXPECT_TRUE(file.read(buffer.data(), size));
 
 		// Load the 3mf from a buffer, not a file


### PR DESCRIPTION
* 32 bit builds need explicit cast when converting uint64 to size_t