### PR TITLE
Make NMR_COM_NATIVE settable on the command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_INSTALL_BINDIR bin CACHE PATH "directory for installing binary files")
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "directory for installing library files")
 set(CMAKE_INSTALL_INCLUDEDIR include/lib3mf CACHE PATH "directory for installing header files")
 
-set(NMR_COM_NATIVE FALSE) # by default, do not actually implement a COM interface
+set(NMR_COM_NATIVE CACHE BOOL FALSE) # by default, do not actually implement a COM interface
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # using GCC
   add_definitions(-DBUILD_DLL)


### PR DESCRIPTION
This resolves issue [77](https://github.com/3MFConsortium/lib3mf/issues/77)

Added "CACHE BOOL" when setting NMR_COM_NATIVE to FALSE so that it does not overwrite the value set on the cmake command line or in the CMakeCache.txt.