### PR TITLE
Update copyright to 3MF-Consortium

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,4 @@
-Copyright (C) 2017 Autodesk Inc.
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/SDK/GenerateSDK.sh
+++ b/SDK/GenerateSDK.sh
@@ -23,8 +23,9 @@ echo Clean artifacts-folder $SDKARTIFACTS
 rm -rf $SDKARTIFACTS
 mkdir $SDKARTIFACTS
 
-#=Copy docs and examples=#
-echo Copy docs and examples
+#=Copy license, docs, examples=#
+echo Copy license, docs and examples
+cp  ../LICENSE $SDKARTIFACTS
 cp -r Doc $SDKARTIFACTS
 cp -r Examples $SDKARTIFACTS
 


### PR DESCRIPTION
All former copyright holders (Microsoft Corporation, Autodesk Inc. and
netfabb GmbH) have contributed to lib3MF and continue to contribute to
lib3MF as members of the 3MF consortium.

The binary pakage lib3MF_sdk.zip now contains the LICENSE file.