### PR TITLE
Remove strict checking of ZIP files

### DIFF
--- a/Source/Common/OPC/NMR_OpcPackageReader.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageReader.cpp
@@ -142,7 +142,7 @@ namespace NMR {
 			if (m_ZIPsource == nullptr)
 				throw CNMRException(NMR_ERROR_COULDNOTREADZIPFILE);
 
-			m_ZIParchive = zip_open_from_source(m_ZIPsource, ZIP_RDONLY | ZIP_CHECKCONS, &m_ZIPError);
+			m_ZIParchive = zip_open_from_source(m_ZIPsource, ZIP_RDONLY, &m_ZIPError);
 			if (m_ZIParchive == nullptr)
 				throw CNMRException(NMR_ERROR_COULDNOTREADZIPFILE);
 


### PR DESCRIPTION
Improves https://github.com/3MFConsortium/lib3mf/issues/81

This allows lib3MF to read ZIP files with invalid headers.
These mostly are files which 7Zip reports to have "Warning: Headers error".
Files with full "Headers error" will still not be read by lib3MF.

See https://libzip.org/documentation/zip_open.html for reference of the
flag in question.