### PR TITLE
Update copyright to 3MF-Consortium

### DIFF
--- a/Include/Common/3MF_ProgressMonitor.h
+++ b/Include/Common/3MF_ProgressMonitor.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2018 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/3MF_ProgressTypes.h
+++ b/Include/Common/3MF_ProgressTypes.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2018 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Math/NMR_Geometry.h
+++ b/Include/Common/Math/NMR_Geometry.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Math/NMR_Matrix.h
+++ b/Include/Common/Math/NMR_Matrix.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Math/NMR_PairMatchingTree.h
+++ b/Include/Common/Math/NMR_PairMatchingTree.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Math/NMR_Vector.h
+++ b/Include/Common/Math/NMR_Vector.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Math/NMR_VectorTree.h
+++ b/Include/Common/Math/NMR_VectorTree.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Mesh/NMR_BeamLattice.h
+++ b/Include/Common/Mesh/NMR_BeamLattice.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Mesh/NMR_Mesh.h
+++ b/Include/Common/Mesh/NMR_Mesh.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Mesh/NMR_MeshBuilder.h
+++ b/Include/Common/Mesh/NMR_MeshBuilder.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Mesh/NMR_MeshTypes.h
+++ b/Include/Common/Mesh/NMR_MeshTypes.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshExport/NMR_MeshExportEdgeMap.h
+++ b/Include/Common/MeshExport/NMR_MeshExportEdgeMap.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshExport/NMR_MeshExporter.h
+++ b/Include/Common/MeshExport/NMR_MeshExporter.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshExport/NMR_MeshExporter_STL.h
+++ b/Include/Common/MeshExport/NMR_MeshExporter_STL.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshImport/NMR_MeshImporter.h
+++ b/Include/Common/MeshImport/NMR_MeshImporter.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshImport/NMR_MeshImporter_STL.h
+++ b/Include/Common/MeshImport/NMR_MeshImporter_STL.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformation.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformation.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformationContainer.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformationContainer.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformationFactory.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformationFactory.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformationHandler.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformationHandler.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformationTypes.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformationTypes.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformation_BaseMaterials.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformation_BaseMaterials.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformation_NodeColors.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformation_NodeColors.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformation_Slices.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformation_Slices.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/MeshInformation/NMR_MeshInformation_TexCoords.h
+++ b/Include/Common/MeshInformation/NMR_MeshInformation_TexCoords.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_Assertion.h
+++ b/Include/Common/NMR_Assertion.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_ErrorConst.h
+++ b/Include/Common/NMR_ErrorConst.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_Exception.h
+++ b/Include/Common/NMR_Exception.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_Exception_Windows.h
+++ b/Include/Common/NMR_Exception_Windows.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_Local.h
+++ b/Include/Common/NMR_Local.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_PagedVector.h
+++ b/Include/Common/NMR_PagedVector.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_StringUtils.h
+++ b/Include/Common/NMR_StringUtils.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_Types.h
+++ b/Include/Common/NMR_Types.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/NMR_UUID.h
+++ b/Include/Common/NMR_UUID.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/OPC/NMR_OpcPackageContentTypesReader.h
+++ b/Include/Common/OPC/NMR_OpcPackageContentTypesReader.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/OPC/NMR_OpcPackagePart.h
+++ b/Include/Common/OPC/NMR_OpcPackagePart.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/OPC/NMR_OpcPackageReader.h
+++ b/Include/Common/OPC/NMR_OpcPackageReader.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/OPC/NMR_OpcPackageRelationship.h
+++ b/Include/Common/OPC/NMR_OpcPackageRelationship.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/OPC/NMR_OpcPackageRelationshipReader.h
+++ b/Include/Common/OPC/NMR_OpcPackageRelationshipReader.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/OPC/NMR_OpcPackageTypes.h
+++ b/Include/Common/OPC/NMR_OpcPackageTypes.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/OPC/NMR_OpcPackageWriter.h
+++ b/Include/Common/OPC/NMR_OpcPackageWriter.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_CComPtr.h
+++ b/Include/Common/Platform/NMR_CComPtr.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH 
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_COM_Emulation.h
+++ b/Include/Common/Platform/NMR_COM_Emulation.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_COM_Native.h
+++ b/Include/Common/Platform/NMR_COM_Native.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream.h
+++ b/Include/Common/Platform/NMR_ExportStream.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream_COM.h
+++ b/Include/Common/Platform/NMR_ExportStream_COM.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream_Callback.h
+++ b/Include/Common/Platform/NMR_ExportStream_Callback.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream_Dummy.h
+++ b/Include/Common/Platform/NMR_ExportStream_Dummy.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream_GCC_Native.h
+++ b/Include/Common/Platform/NMR_ExportStream_GCC_Native.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream_GCC_Win32.h
+++ b/Include/Common/Platform/NMR_ExportStream_GCC_Win32.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream_Memory.h
+++ b/Include/Common/Platform/NMR_ExportStream_Memory.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ExportStream_ZIP.h
+++ b/Include/Common/Platform/NMR_ExportStream_ZIP.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_IStream.h
+++ b/Include/Common/Platform/NMR_IStream.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ImportStream.h
+++ b/Include/Common/Platform/NMR_ImportStream.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ImportStream_COM.h
+++ b/Include/Common/Platform/NMR_ImportStream_COM.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ImportStream_Callback.h
+++ b/Include/Common/Platform/NMR_ImportStream_Callback.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ImportStream_GCC_Native.h
+++ b/Include/Common/Platform/NMR_ImportStream_GCC_Native.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ImportStream_GCC_Win32.h
+++ b/Include/Common/Platform/NMR_ImportStream_GCC_Win32.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ImportStream_Memory.h
+++ b/Include/Common/Platform/NMR_ImportStream_Memory.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_ImportStream_ZIP.h
+++ b/Include/Common/Platform/NMR_ImportStream_ZIP.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_Platform.h
+++ b/Include/Common/Platform/NMR_Platform.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_PortableZIPWriter.h
+++ b/Include/Common/Platform/NMR_PortableZIPWriter.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_PortableZIPWriterEntry.h
+++ b/Include/Common/Platform/NMR_PortableZIPWriterEntry.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_PortableZIPWriterTypes.h
+++ b/Include/Common/Platform/NMR_PortableZIPWriterTypes.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_SAL.h
+++ b/Include/Common/Platform/NMR_SAL.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_Time.h
+++ b/Include/Common/Platform/NMR_Time.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_WinTypes.h
+++ b/Include/Common/Platform/NMR_WinTypes.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_XmlReader.h
+++ b/Include/Common/Platform/NMR_XmlReader.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_XmlReader_Native.h
+++ b/Include/Common/Platform/NMR_XmlReader_Native.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_XmlWriter.h
+++ b/Include/Common/Platform/NMR_XmlWriter.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Common/Platform/NMR_XmlWriter_Native.h
+++ b/Include/Common/Platform/NMR_XmlWriter_Native.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMFactory.h
+++ b/Include/Model/COM/NMR_COMFactory.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_Model.h
+++ b/Include/Model/COM/NMR_COMInterface_Model.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelAttachment.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelAttachment.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelBaseMaterial.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelBaseMaterial.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelBuildItem.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelBuildItem.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelBuildItemIterator.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelBuildItemIterator.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelComponent.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelComponent.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelComponentsObject.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelComponentsObject.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelDefaultPropertyHandler.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelDefaultPropertyHandler.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelFactory.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelFactory.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelMeshBeamSet.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelMeshBeamSet.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelMeshObject.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelMeshObject.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelPropertyHandler.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelPropertyHandler.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelReader.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelReader.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelResourceFactory.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelResourceFactory.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelResourceIterator.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelResourceIterator.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelTexture2D.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelTexture2D.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelTextureAttachment.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelTextureAttachment.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelTextureStream.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelTextureStream.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_ModelWriter.h
+++ b/Include/Model/COM/NMR_COMInterface_ModelWriter.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterface_Slice.h
+++ b/Include/Model/COM/NMR_COMInterface_Slice.h
@@ -1,3 +1,35 @@
+/*++
+
+Copyright (C) 2018 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+NMR_COMInterface_Slice.h: defines COM interface for the slice class
+
+--*/
+
 #ifndef __NMR_COMINTERFACE_SLICE
 #define __NMR_COMINTERFACE_SLICE
 
@@ -87,3 +119,4 @@ namespace NMR {
 }
 
 #endif
+

--- a/Include/Model/COM/NMR_COMInterfaces.h
+++ b/Include/Model/COM/NMR_COMInterfaces.h
@@ -1,8 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMInterfaces_Base.h
+++ b/Include/Model/COM/NMR_COMInterfaces_Base.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_COMVersion.h.in
+++ b/Include/Model/COM/NMR_COMVersion.h.in
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/COM/NMR_DLLInterfaces.h
+++ b/Include/Model/COM/NMR_DLLInterfaces.h
@@ -1,8 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_Model.h
+++ b/Include/Model/Classes/NMR_Model.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelAttachment.h
+++ b/Include/Model/Classes/NMR_ModelAttachment.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelBaseMaterial.h
+++ b/Include/Model/Classes/NMR_ModelBaseMaterial.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelBaseMaterials.h
+++ b/Include/Model/Classes/NMR_ModelBaseMaterials.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelBuildItem.h
+++ b/Include/Model/Classes/NMR_ModelBuildItem.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelComponent.h
+++ b/Include/Model/Classes/NMR_ModelComponent.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelComponentsObject.h
+++ b/Include/Model/Classes/NMR_ModelComponentsObject.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelConstants.h
+++ b/Include/Model/Classes/NMR_ModelConstants.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelDefaultProperty.h
+++ b/Include/Model/Classes/NMR_ModelDefaultProperty.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelDefaultProperty_BaseMaterial.h
+++ b/Include/Model/Classes/NMR_ModelDefaultProperty_BaseMaterial.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelDefaultProperty_Color.h
+++ b/Include/Model/Classes/NMR_ModelDefaultProperty_Color.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelDefaultProperty_TexCoord2D.h
+++ b/Include/Model/Classes/NMR_ModelDefaultProperty_TexCoord2D.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelMeshBeamLatticeAttributes.h
+++ b/Include/Model/Classes/NMR_ModelMeshBeamLatticeAttributes.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelMeshObject.h
+++ b/Include/Model/Classes/NMR_ModelMeshObject.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelMetaData.h
+++ b/Include/Model/Classes/NMR_ModelMetaData.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelObject.h
+++ b/Include/Model/Classes/NMR_ModelObject.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelResource.h
+++ b/Include/Model/Classes/NMR_ModelResource.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelSliceResource.h
+++ b/Include/Model/Classes/NMR_ModelSliceResource.h
@@ -1,5 +1,37 @@
+/*++
+
+Copyright (C) 2018 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+NMR_ModelSliceResource.h: defines the resource object for slices
+
+--*/
+
 #ifndef __NMR_SLICERESOURCE
-  #define __NMR_SLICERESOURCE
+#define __NMR_SLICERESOURCE
 
 #include "Common/NMR_Types.h"
 #include "Common/Mesh/NMR_MeshTypes.h"

--- a/Include/Model/Classes/NMR_ModelTexture2D.h
+++ b/Include/Model/Classes/NMR_ModelTexture2D.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelTextureAttachment.h
+++ b/Include/Model/Classes/NMR_ModelTextureAttachment.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_ModelTypes.h
+++ b/Include/Model/Classes/NMR_ModelTypes.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Classes/NMR_PackageResourceID.h
+++ b/Include/Model/Classes/NMR_PackageResourceID.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beam.h
+++ b/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beam.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamLattice.h
+++ b/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamLattice.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSet.h
+++ b/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSet.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSets.h
+++ b/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSets.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beams.h
+++ b/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beams.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Ref.h
+++ b/Include/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Ref.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReader.h
+++ b/Include/Model/Reader/NMR_ModelReader.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReaderNode.h
+++ b/Include/Model/Reader/NMR_ModelReaderNode.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReaderNode_Model.h
+++ b/Include/Model/Reader/NMR_ModelReaderNode_Model.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReaderWarnings.h
+++ b/Include/Model/Reader/NMR_ModelReaderWarnings.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReader_3MF.h
+++ b/Include/Model/Reader/NMR_ModelReader_3MF.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReader_3MF_Native.h
+++ b/Include/Model/Reader/NMR_ModelReader_3MF_Native.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReader_ColorMapping.h
+++ b/Include/Model/Reader/NMR_ModelReader_ColorMapping.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReader_InstructionElement.h
+++ b/Include/Model/Reader/NMR_ModelReader_InstructionElement.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReader_STL.h
+++ b/Include/Model/Reader/NMR_ModelReader_STL.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/NMR_ModelReader_TexCoordMapping.h
+++ b/Include/Model/Reader/NMR_ModelReader_TexCoordMapping.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Polygon.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Polygon.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Segment.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Segment.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Slice.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Slice.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRef.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRef.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefModel.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefModel.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefResources.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefResources.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceStack.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceStack.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertex.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertex.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertices.h
+++ b/Include/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertices.h
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Build.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Build.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_BuildItem.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_BuildItem.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Color.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Color.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Component.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Component.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Components.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Components.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Material.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Material.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Mesh.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Mesh.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Object.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Object.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Resources.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Resources.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Texture.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Texture.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertex.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertex.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertices.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertices.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Triangle.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Triangle.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Triangles.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Triangles.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Vertex.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Vertex.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v093/NMR_ModelReaderNode093_Vertices.h
+++ b/Include/Model/Reader/v093/NMR_ModelReaderNode093_Vertices.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterial.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterial.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterials.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterials.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Build.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Build.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_BuildItem.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_BuildItem.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Color.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Color.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Colors.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Colors.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Component.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Component.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Components.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Components.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Mesh.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Mesh.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_MetaData.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_MetaData.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Object.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Object.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Resources.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Resources.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Tex2Coord.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Tex2Coord.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Tex2DGroup.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Tex2DGroup.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Texture2D.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Texture2D.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Triangle.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Triangle.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Triangles.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Triangles.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Vertex.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Vertex.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Reader/v100/NMR_ModelReaderNode100_Vertices.h
+++ b/Include/Model/Reader/v100/NMR_ModelReaderNode100_Vertices.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriter.h
+++ b/Include/Model/Writer/NMR_ModelWriter.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriterNode.h
+++ b/Include/Model/Writer/NMR_ModelWriterNode.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriter_3MF.h
+++ b/Include/Model/Writer/NMR_ModelWriter_3MF.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriter_3MF_Native.h
+++ b/Include/Model/Writer/NMR_ModelWriter_3MF_Native.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriter_ColorMapping.h
+++ b/Include/Model/Writer/NMR_ModelWriter_ColorMapping.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriter_STL.h
+++ b/Include/Model/Writer/NMR_ModelWriter_STL.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriter_TexCoordMapping.h
+++ b/Include/Model/Writer/NMR_ModelWriter_TexCoordMapping.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/NMR_ModelWriter_TexCoordMappingContainer.h
+++ b/Include/Model/Writer/NMR_ModelWriter_TexCoordMappingContainer.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.h
+++ b/Include/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Include/Model/Writer/v100/NMR_ModelWriterNode100_Model.h
+++ b/Include/Model/Writer/v100/NMR_ModelWriterNode100_Model.h
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/SDK/Examples/Source/BeamLattice.cpp
+++ b/SDK/Examples/Source/BeamLattice.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc.
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SDK/Examples/Source/ColorCube.cpp
+++ b/SDK/Examples/Source/ColorCube.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SDK/Examples/Source/Components.cpp
+++ b/SDK/Examples/Source/Components.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc.
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SDK/Examples/Source/Converter.cpp
+++ b/SDK/Examples/Source/Converter.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SDK/Examples/Source/Cube.cpp
+++ b/SDK/Examples/Source/Cube.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc.
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SDK/Examples/Source/ExtractInfo.cpp
+++ b/SDK/Examples/Source/ExtractInfo.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc.
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SDK/Examples/Source/Slice.cpp
+++ b/SDK/Examples/Source/Slice.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc.
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SDK/Examples/Source/TextureCube.cpp
+++ b/SDK/Examples/Source/TextureCube.cpp
@@ -1,7 +1,7 @@
 /*++
 
-© 2017 Autodesk Inc.
-© 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Source/Common/3MF_ProgressMonitor.cpp
+++ b/Source/Common/3MF_ProgressMonitor.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2018 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Math/NMR_Matrix.cpp
+++ b/Source/Common/Math/NMR_Matrix.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Math/NMR_PairMatchingTree.cpp
+++ b/Source/Common/Math/NMR_PairMatchingTree.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Math/NMR_Vector.cpp
+++ b/Source/Common/Math/NMR_Vector.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Math/NMR_VectorTree.cpp
+++ b/Source/Common/Math/NMR_VectorTree.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Mesh/NMR_BeamLattice.cpp
+++ b/Source/Common/Mesh/NMR_BeamLattice.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Mesh/NMR_Mesh.cpp
+++ b/Source/Common/Mesh/NMR_Mesh.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Mesh/NMR_MeshBuilder.cpp
+++ b/Source/Common/Mesh/NMR_MeshBuilder.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshExport/NMR_MeshExportEdgeMap.cpp
+++ b/Source/Common/MeshExport/NMR_MeshExportEdgeMap.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshExport/NMR_MeshExporter.cpp
+++ b/Source/Common/MeshExport/NMR_MeshExporter.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshExport/NMR_MeshExporter_STL.cpp
+++ b/Source/Common/MeshExport/NMR_MeshExporter_STL.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshImport/NMR_MeshImporter.cpp
+++ b/Source/Common/MeshImport/NMR_MeshImporter.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshImport/NMR_MeshImporter_STL.cpp
+++ b/Source/Common/MeshImport/NMR_MeshImporter_STL.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshInformation/NMR_MeshInformation.cpp
+++ b/Source/Common/MeshInformation/NMR_MeshInformation.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshInformation/NMR_MeshInformationContainer.cpp
+++ b/Source/Common/MeshInformation/NMR_MeshInformationContainer.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshInformation/NMR_MeshInformationFactory.cpp
+++ b/Source/Common/MeshInformation/NMR_MeshInformationFactory.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshInformation/NMR_MeshInformationHandler.cpp
+++ b/Source/Common/MeshInformation/NMR_MeshInformationHandler.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshInformation/NMR_MeshInformation_BaseMaterials.cpp
+++ b/Source/Common/MeshInformation/NMR_MeshInformation_BaseMaterials.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshInformation/NMR_MeshInformation_NodeColors.cpp
+++ b/Source/Common/MeshInformation/NMR_MeshInformation_NodeColors.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/MeshInformation/NMR_MeshInformation_TexCoords.cpp
+++ b/Source/Common/MeshInformation/NMR_MeshInformation_TexCoords.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/NMR_Exception.cpp
+++ b/Source/Common/NMR_Exception.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/NMR_Exception_Windows.cpp
+++ b/Source/Common/NMR_Exception_Windows.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/NMR_StringUtils.cpp
+++ b/Source/Common/NMR_StringUtils.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/NMR_UUID.cpp
+++ b/Source/Common/NMR_UUID.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/OPC/NMR_OpcPackageContentTypesReader.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageContentTypesReader.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/OPC/NMR_OpcPackagePart.cpp
+++ b/Source/Common/OPC/NMR_OpcPackagePart.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/OPC/NMR_OpcPackageReader.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageReader.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/OPC/NMR_OpcPackageRelationship.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageRelationship.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/OPC/NMR_OpcPackageRelationshipReader.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageRelationshipReader.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/OPC/NMR_OpcPackageWriter.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageWriter.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream.cpp
+++ b/Source/Common/Platform/NMR_ExportStream.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream_COM.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_COM.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream_Callback.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_Callback.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream_Dummy.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_Dummy.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream_GCC_Native.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_GCC_Native.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream_GCC_Win32.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_GCC_Win32.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream_Memory.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_Memory.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ExportStream_ZIP.cpp
+++ b/Source/Common/Platform/NMR_ExportStream_ZIP.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ImportStream_COM.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_COM.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ImportStream_Callback.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Callback.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ImportStream_GCC_Native.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_GCC_Native.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ImportStream_GCC_Win32.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_GCC_Win32.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ImportStream_Memory.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Memory.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_ImportStream_ZIP.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_ZIP.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_Platform_COM.cpp
+++ b/Source/Common/Platform/NMR_Platform_COM.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_Platform_GCC.cpp
+++ b/Source/Common/Platform/NMR_Platform_GCC.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_PortableZIPWriter.cpp
+++ b/Source/Common/Platform/NMR_PortableZIPWriter.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2018 Autodesk Inc.
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_PortableZIPWriterEntry.cpp
+++ b/Source/Common/Platform/NMR_PortableZIPWriterEntry.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_Time.cpp
+++ b/Source/Common/Platform/NMR_Time.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_XmlReader.cpp
+++ b/Source/Common/Platform/NMR_XmlReader.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_XmlReader_Native.cpp
+++ b/Source/Common/Platform/NMR_XmlReader_Native.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_XmlWriter.cpp
+++ b/Source/Common/Platform/NMR_XmlWriter.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Common/Platform/NMR_XmlWriter_Native.cpp
+++ b/Source/Common/Platform/NMR_XmlWriter_Native.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Main/dllmain.cpp
+++ b/Source/Main/dllmain.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Main/main.cpp
+++ b/Source/Main/main.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMFactory.cpp
+++ b/Source/Model/COM/NMR_COMFactory.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_GCC.cpp
+++ b/Source/Model/COM/NMR_COMInterface_GCC.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_Model.cpp
+++ b/Source/Model/COM/NMR_COMInterface_Model.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelAttachment.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelAttachment.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C)  Microsoft Corporation.
-Copyright (C) netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelBaseMaterial.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelBaseMaterial.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelBuildItem.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelBuildItem.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelBuildItemIterator.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelBuildItemIterator.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelComponent.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelComponent.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelComponentsObject.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelComponentsObject.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelDefaultPropertyHandler.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelDefaultPropertyHandler.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelFactory.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelFactory.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelMeshBeamSet.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelMeshBeamSet.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelMeshObject.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelMeshObject.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelPropertyHandler.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelPropertyHandler.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelReader.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelReader.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelResourceFactory.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelResourceFactory.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelResourceIterator.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelResourceIterator.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelTexture2D.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelTexture2D.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_ModelWriter.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelWriter.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_COMInterface_Slice.cpp
+++ b/Source/Model/COM/NMR_COMInterface_Slice.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/COM/NMR_DLLInterfaces.cpp
+++ b/Source/Model/COM/NMR_DLLInterfaces.cpp
@@ -1,8 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_Model.cpp
+++ b/Source/Model/Classes/NMR_Model.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelAttachment.cpp
+++ b/Source/Model/Classes/NMR_ModelAttachment.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelBaseMaterial.cpp
+++ b/Source/Model/Classes/NMR_ModelBaseMaterial.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelBaseMaterials.cpp
+++ b/Source/Model/Classes/NMR_ModelBaseMaterials.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelBuildItem.cpp
+++ b/Source/Model/Classes/NMR_ModelBuildItem.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelComponent.cpp
+++ b/Source/Model/Classes/NMR_ModelComponent.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelComponentsObject.cpp
+++ b/Source/Model/Classes/NMR_ModelComponentsObject.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelDefaultProperty.cpp
+++ b/Source/Model/Classes/NMR_ModelDefaultProperty.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelDefaultProperty_BaseMaterial.cpp
+++ b/Source/Model/Classes/NMR_ModelDefaultProperty_BaseMaterial.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelDefaultProperty_Color.cpp
+++ b/Source/Model/Classes/NMR_ModelDefaultProperty_Color.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelDefaultProperty_TexCoord2D.cpp
+++ b/Source/Model/Classes/NMR_ModelDefaultProperty_TexCoord2D.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelMeshBeamLatticeAttributes.cpp
+++ b/Source/Model/Classes/NMR_ModelMeshBeamLatticeAttributes.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelMeshObject.cpp
+++ b/Source/Model/Classes/NMR_ModelMeshObject.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelMetaData.cpp
+++ b/Source/Model/Classes/NMR_ModelMetaData.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelObject.cpp
+++ b/Source/Model/Classes/NMR_ModelObject.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelResource.cpp
+++ b/Source/Model/Classes/NMR_ModelResource.cpp
@@ -1,7 +1,7 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/Source/Model/Classes/NMR_ModelSliceStackResource.cpp
+++ b/Source/Model/Classes/NMR_ModelSliceStackResource.cpp
@@ -1,3 +1,35 @@
+/*++
+
+Copyright (C) 2018 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+NMR_ModelSliceStackResource.h: implements the resource object for a slice stack
+
+--*/
+
 #include "Model/Classes/NMR_ModelSliceResource.h"
 #include "Model/Classes/NMR_ModelResource.h"
 #include "Common/NMR_Exception.h"
@@ -203,3 +235,4 @@ namespace NMR {
 		return true;
 	}
 }
+

--- a/Source/Model/Classes/NMR_ModelTexture2D.cpp
+++ b/Source/Model/Classes/NMR_ModelTexture2D.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_ModelTextureAttachment.cpp
+++ b/Source/Model/Classes/NMR_ModelTextureAttachment.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Classes/NMR_PackageResourceID.cpp
+++ b/Source/Model/Classes/NMR_PackageResourceID.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beam.cpp
+++ b/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beam.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamLattice.cpp
+++ b/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamLattice.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSet.cpp
+++ b/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSet.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSets.cpp
+++ b/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_BeamSets.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beams.cpp
+++ b/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Beams.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Ref.cpp
+++ b/Source/Model/Reader/BeamLattice1702/NMR_ModelReaderNode_BeamLattice1702_Ref.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReader.cpp
+++ b/Source/Model/Reader/NMR_ModelReader.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReaderNode.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderNode.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReaderNode_Model.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderNode_Model.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReaderWarnings.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderWarnings.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReader_3MF.cpp
+++ b/Source/Model/Reader/NMR_ModelReader_3MF.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReader_3MF_Native.cpp
+++ b/Source/Model/Reader/NMR_ModelReader_3MF_Native.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReader_ColorMapping.cpp
+++ b/Source/Model/Reader/NMR_ModelReader_ColorMapping.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReader_InstructionElement.cpp
+++ b/Source/Model/Reader/NMR_ModelReader_InstructionElement.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReader_STL.cpp
+++ b/Source/Model/Reader/NMR_ModelReader_STL.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/NMR_ModelReader_TexCoordMapping.cpp
+++ b/Source/Model/Reader/NMR_ModelReader_TexCoordMapping.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Polygon.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Polygon.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Segment.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Segment.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Slice.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Slice.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRef.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRef.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefModel.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefModel.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefResources.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefResources.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceStack.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceStack.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertex.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertex.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertices.cpp
+++ b/Source/Model/Reader/Slice1507/NMR_ModelReader_Slice1507_Vertices.cpp
@@ -1,6 +1,6 @@
 /*++
 
-Copyright (C) 2017 Autodesk Inc.
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Build.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Build.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_BuildItem.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_BuildItem.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Color.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Color.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Component.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Component.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Components.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Components.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Material.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Material.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Mesh.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Mesh.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Object.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Object.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Resources.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Resources.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Texture.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Texture.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertex.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertex.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertices.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_TextureVertices.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Triangle.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Triangle.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Triangles.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Triangles.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Vertex.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Vertex.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Vertices.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Vertices.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterial.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterial.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterials.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_BaseMaterials.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Build.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Build.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_BuildItem.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_BuildItem.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Color.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Color.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Colors.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Colors.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Component.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Component.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Components.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Components.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Mesh.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Mesh.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_MetaData.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_MetaData.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Object.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Object.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Resources.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Resources.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Tex2Coord.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Tex2Coord.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Tex2DGroup.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Tex2DGroup.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Texture2D.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Texture2D.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Triangle.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Triangle.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Triangles.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Triangles.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertex.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertex.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertices.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertices.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriterNode.cpp
+++ b/Source/Model/Writer/NMR_ModelWriterNode.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter_3MF.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_3MF.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter_3MF_Native.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_3MF_Native.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter_3MF_OPC.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_3MF_OPC.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter_ColorMapping.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_ColorMapping.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter_STL.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_STL.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation
-Copyright (C) 2015 netfabb GmbH (Original Author)
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter_TexCoordMapping.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_TexCoordMapping.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/NMR_ModelWriter_TexCoordMappingContainer.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_TexCoordMappingContainer.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Model.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Model.cpp
@@ -1,7 +1,6 @@
 /*++
 
-Copyright (C) 2015 Microsoft Corporation (Original Author)
-Copyright (C) 2015 netfabb GmbH
+Copyright (C) 2018 3MF Consortium
 
 All rights reserved.
 

--- a/UnitTests/CPP/Include/UnitTest_Utilities.h
+++ b/UnitTests/CPP/Include/UnitTest_Utilities.h
@@ -1,6 +1,7 @@
 /*++
 
 Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/CPP/Source/UnitTest_AllTests.cpp
+++ b/UnitTests/CPP/Source/UnitTest_AllTests.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/CPP/Source/UnitTest_Geometry.cpp
+++ b/UnitTests/CPP/Source/UnitTest_Geometry.cpp
@@ -1,6 +1,7 @@
 /*++
 
 Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/CPP/Source/UnitTest_Mesh.cpp
+++ b/UnitTests/CPP/Source/UnitTest_Mesh.cpp
@@ -1,6 +1,7 @@
 /*++
 
 Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/CPP/Source/UnitTest_MeshFormat_STL.cpp
+++ b/UnitTests/CPP/Source/UnitTest_MeshFormat_STL.cpp
@@ -1,6 +1,7 @@
 /*++
 
 Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/CPP/Source/UnitTest_Model.cpp
+++ b/UnitTests/CPP/Source/UnitTest_Model.cpp
@@ -1,6 +1,7 @@
 /*++
 
 Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/CPP/Source/UnitTest_ModelFactory.cpp
+++ b/UnitTests/CPP/Source/UnitTest_ModelFactory.cpp
@@ -1,6 +1,7 @@
 /*++
 
 Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/CPP/Source/UnitTest_ZIP.cpp
+++ b/UnitTests/CPP/Source/UnitTest_ZIP.cpp
@@ -1,6 +1,7 @@
 /*++
 
 Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Include/UnitTest_Utilities.h
+++ b/UnitTests/C_Interface/Include/UnitTest_Utilities.h
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_AllTests.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_AllTests.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_Attachments.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_Attachments.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_BatchTests.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_BatchTests.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_BeamLattice.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_BeamLattice.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_Extensions.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_Extensions.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_OPC_Issues.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_OPC_Issues.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_Production.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_Production.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_ProgressCallback.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_ProgressCallback.cpp
@@ -1,6 +1,7 @@
 ﻿/*++
 
-Copyright (C) 2018 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_ReadWrite.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_ReadWrite.cpp
@@ -1,6 +1,7 @@
 ﻿/*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_ReaderStrictMode.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_ReaderStrictMode.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_Slice.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_Slice.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_Textures.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_Textures.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/UnitTests/C_Interface/Source/UnitTest_Thumbnails.cpp
+++ b/UnitTests/C_Interface/Source/UnitTest_Thumbnails.cpp
@@ -1,6 +1,7 @@
 /*++
 
-Copyright (C) 2017 Autodesk, Inc.
+Copyright (C) 2018 3MF Consortium
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
All former copyright holders (Microsoft Corporation, Autodesk Inc. and
netfabb GmbH) have contributed to lib3MF and continue to contribute to
lib3MF as members of the 3MF consortium.

This is reflected in all source files now.

This PR addresses https://github.com/3MFConsortium/lib3mf/issues/88 .