### PR TITLE
Inconsistent ZIP files cause warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project (lib3MF)
 # Define Version
 set(LIB3MF_VERSION_MAJOR 1)				# increase on every backward-compatibility breaking change of the API
 set(LIB3MF_VERSION_MINOR 4)				# increase on every backward compatible change of the API
-set(LIB3MF_VERSION_MICRO 3)				# increase on on every change that does not alter the API
+set(LIB3MF_VERSION_MICRO 4)				# increase on on every change that does not alter the API
 
 set(CMAKE_INSTALL_BINDIR bin CACHE PATH "directory for installing binary files")
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "directory for installing library files")

--- a/Include/Common/NMR_ErrorConst.h
+++ b/Include/Common/NMR_ErrorConst.h
@@ -281,6 +281,9 @@ NMR_ErrorConst.h defines all error code constants.
 // Error in zip-callback
 #define NMR_ERROR_ZIPCALLBACK 0x104C
 
+// ZIP contains inconsistencies
+#define NMR_ERROR_ZIPCONTAINSINCONSISTENCIES 0x104D
+
 /*-------------------------------------------------------------------
 Core framework error codes (0x2XXX)
 -------------------------------------------------------------------*/

--- a/Source/Common/NMR_Exception.cpp
+++ b/Source/Common/NMR_Exception.cpp
@@ -125,6 +125,7 @@ namespace NMR {
 		case NMR_ERROR_ZIPENTRYNON64_TOOLARGE: return "A ZIP Entry is too large for non zip64 zip-file";
 		case NMR_ERROR_ATTACHMENTTOOLARGE: return "An individual custom attachment is too large.";
 		case NMR_ERROR_ZIPCALLBACK: return "Error in libzip callback.";
+		case NMR_ERROR_ZIPCONTAINSINCONSISTENCIES: return "ZIP file contains inconsistencies. It might load with errors or incorrectly.";
 
 
 		// Unhandled exception

--- a/Source/Common/OPC/NMR_OpcPackageReader.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageReader.cpp
@@ -143,8 +143,13 @@ namespace NMR {
 				throw CNMRException(NMR_ERROR_COULDNOTREADZIPFILE);
 
 			m_ZIParchive = zip_open_from_source(m_ZIPsource, ZIP_RDONLY | ZIP_CHECKCONS, &m_ZIPError);
-			if (m_ZIParchive == nullptr)
-				throw CNMRException(NMR_ERROR_COULDNOTREADZIPFILE);
+			if (m_ZIParchive == nullptr) {
+				m_ZIParchive = zip_open_from_source(m_ZIPsource, ZIP_RDONLY, &m_ZIPError);
+				if (m_ZIParchive == nullptr)
+					throw CNMRException(NMR_ERROR_COULDNOTREADZIPFILE);
+				else
+					m_pWarnings->addException(CNMRException(NMR_ERROR_ZIPCONTAINSINCONSISTENCIES), mrwInvalidMandatoryValue);
+			}
 
 			// Get ZIP Content
 			nfInt64 nEntryCount = zip_get_num_entries(m_ZIParchive, ZIP_FL_UNCHANGED);


### PR DESCRIPTION
Resolves #81

This allows lib3MF to read ZIP files with invalid headers.
- These mostly are files which 7Zip reports to have "Warning: Headers error": Lib3MF will issue a warning for these files, but attempt to read them.
- Files with full "Headers error" will still not be read by lib3MF.

See https://libzip.org/documentation/zip_open.html for reference of the flag in question.