### PR TITLE
Use Windows API for GUID generation on MinGW.

### DIFF
--- a/Source/Common/NMR_UUID.cpp
+++ b/Source/Common/NMR_UUID.cpp
@@ -37,8 +37,8 @@ NMR_UUID.cpp implements a datatype and functions to handle UUIDs
 
 #include <algorithm>
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-#include <Objbase.h>
+#if defined(_WIN32)
+#include <objbase.h>
 #include <iomanip>
 #else
 #include <uuid/uuid.h>
@@ -48,7 +48,7 @@ namespace NMR
 {
 	CUUID::CUUID()
 	{
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32)
 		GUID guid;
 		if (CoCreateGuid(&guid) != S_OK)
 			throw CNMRException(NMR_ERROR_UUIDGENERATIONFAILED);


### PR DESCRIPTION
MinGW supports this API and adding libuuid to the Windows build is not easy as this is part of the util-linux package which has lots of Linux specific code.

This is tested via [MXE based build](https://circleci.com/gh/openscad/openscad/295#artifacts/containers/0) for OpenSCAD.

Trivial model (`cube(10);`) exported: [3dmodel.model.txt](https://github.com/3MFConsortium/lib3mf/files/2544563/3dmodel.model.txt)
