### PR TITLE
Update CMake to include building tests as option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ install(DIRECTORY Include/Common DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 #########################################################
-set(LIB3MF_TESTS CACHE BOOL TRUE)
+option(LIB3MF_TESTS "Switch whether the tests of Lib3MF should be build" ON)
 
 message("LIB3MF_TESTS ... " ${LIB3MF_TESTS})
 if(LIB3MF_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,8 @@ install(DIRECTORY Include/Common DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 #########################################################
-if(NOT DEFINED LIB3MF_TESTS)
-	set(LIB3MF_TESTS TRUE)
-endif()
+set(LIB3MF_TESTS CACHE BOOL TRUE)
+
 message("LIB3MF_TESTS ... " ${LIB3MF_TESTS})
 if(LIB3MF_TESTS)
 	include(CTest)


### PR DESCRIPTION
This way it's actually possible to use cmake-gui and build the library without building tests.