### PR TITLE
Reuse memory when reading a Model from a Buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ ENDIF ()
 # increase minor version on every backward compatible change of the API
 # increase patch version on every change that does not alter the API
 project (lib3MF
-	VERSION 1.8.1
+	VERSION 1.8.2
 	DESCRIPTION "Lib3MF is a C++ implementation of the 3D Manufacturing Format file standard.")
 
 include(GNUInstallDirs)

--- a/Include/Common/Platform/NMR_ImportStream_Shared_Memory.h
+++ b/Include/Common/Platform/NMR_ImportStream_Shared_Memory.h
@@ -26,43 +26,32 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Abstract:
 
-NMR_ImportStream_Memory.h defines the CImportStream_Memory Class.
-This is an abstract platform independent class for keeping data in a memory stream.
+NMR_ImportStream_Shared_Memory.h implements the CImportStream_Memory Class.
+This is a platform independent class for keeping data in a memory stream that doesn't own the wrapped buffer.
 
 --*/
 
-#ifndef __NMR_IMPORTSTREAM_MEMORY
-#define __NMR_IMPORTSTREAM_MEMORY
+#ifndef __NMR_IMPORTSTREAM_SHARED_MEMORY
+#define __NMR_IMPORTSTREAM_SHARED_MEMORY
 
-#include "Common/Platform/NMR_ImportStream.h"
+#include "Common/Platform/NMR_ImportStream_Memory.h"
 #include "Common/NMR_Types.h"
 #include "Common/NMR_Local.h"
 
-#define NMR_IMPORTSTREAM_READCHUNKSIZE (1024*1024)
-
-#define NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE (1024ULL*1024ULL*1024ULL*1024ULL)
+#include <vector>
 
 namespace NMR {
 
-	class CImportStream_Memory : public CImportStream {
-	protected:
-		nfUint64 m_cbSize;
-		nfUint64 m_nPosition;
-		
-		virtual const nfByte * getAt(nfUint64 nPosition) = 0;
-	public:
-		virtual ~CImportStream_Memory();
+    class CImportStream_Shared_Memory : public CImportStream_Memory {
+        private:
+                const nfByte * m_Buffer;
+        protected:
+                virtual const nfByte * getAt(nfUint64 nPosition);
+        public:
+            CImportStream_Shared_Memory(_In_ const nfByte * pBuffer, _In_ nfUint64 cbBytes);
+            virtual PImportStream copyToMemory();
+    };
+    
+} // namespace NMR
 
-		virtual nfBool seekPosition(_In_ nfUint64 nPosition, _In_ nfBool bHasToSucceed);
-		virtual nfBool seekForward(_In_ nfUint64 cbBytes, _In_ nfBool bHasToSucceed);
-		virtual nfBool seekFromEnd(_In_ nfUint64 cbBytes, _In_ nfBool bHasToSucceed);
-		virtual nfUint64 getPosition();
-		virtual nfUint64 readBuffer(_In_ nfByte * pBuffer, _In_ nfUint64 cbTotalBytesToRead, nfBool bNeedsToReadAll);
-		virtual nfUint64 retrieveSize();
-		virtual void writeToFile(_In_ const nfWChar * pwszFileName);
-		virtual PImportStream copyToMemory() = 0;
-	};
-
-}
-
-#endif // __NMR_IMPORTSTREAM_MEMORY
+#endif // __NMR_IMPORTSTREAM_SHARED_MEMORY

--- a/Include/Common/Platform/NMR_ImportStream_Unique_Memory.h
+++ b/Include/Common/Platform/NMR_ImportStream_Unique_Memory.h
@@ -26,43 +26,35 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Abstract:
 
-NMR_ImportStream_Memory.h defines the CImportStream_Memory Class.
-This is an abstract platform independent class for keeping data in a memory stream.
+NMR_ImportStream_Unique_Memory.h implements the CImportStream_Memory Class.
+This is a platform independent class for keeping data in a memory stream that owns the wrapped buffer.
 
 --*/
 
-#ifndef __NMR_IMPORTSTREAM_MEMORY
-#define __NMR_IMPORTSTREAM_MEMORY
+#ifndef __NMR_IMPORTSTREAM_UNIQUE_MEMORY
+#define __NMR_IMPORTSTREAM_UNIQUE_MEMORY
 
-#include "Common/Platform/NMR_ImportStream.h"
+#include "Common/Platform/NMR_ImportStream_Memory.h"
 #include "Common/NMR_Types.h"
 #include "Common/NMR_Local.h"
 
-#define NMR_IMPORTSTREAM_READCHUNKSIZE (1024*1024)
-
-#define NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE (1024ULL*1024ULL*1024ULL*1024ULL)
+#include <vector>
 
 namespace NMR {
 
-	class CImportStream_Memory : public CImportStream {
-	protected:
-		nfUint64 m_cbSize;
-		nfUint64 m_nPosition;
+	class CImportStream_Unique_Memory : public CImportStream_Memory {
+		private:
+			std::vector<nfByte> m_Buffer;
+		protected:
+			virtual const nfByte * getAt(nfUint64 nPosition);
+		public:
+			CImportStream_Unique_Memory();
+			CImportStream_Unique_Memory(_In_ CImportStream * pStream, _In_ nfUint64 cbBytesToCopy, _In_ nfBool bNeedsToCopyAllBytes);
+			CImportStream_Unique_Memory(_In_ const nfByte * pBuffer, _In_ nfUint64 cbBytes);
 		
-		virtual const nfByte * getAt(nfUint64 nPosition) = 0;
-	public:
-		virtual ~CImportStream_Memory();
-
-		virtual nfBool seekPosition(_In_ nfUint64 nPosition, _In_ nfBool bHasToSucceed);
-		virtual nfBool seekForward(_In_ nfUint64 cbBytes, _In_ nfBool bHasToSucceed);
-		virtual nfBool seekFromEnd(_In_ nfUint64 cbBytes, _In_ nfBool bHasToSucceed);
-		virtual nfUint64 getPosition();
-		virtual nfUint64 readBuffer(_In_ nfByte * pBuffer, _In_ nfUint64 cbTotalBytesToRead, nfBool bNeedsToReadAll);
-		virtual nfUint64 retrieveSize();
-		virtual void writeToFile(_In_ const nfWChar * pwszFileName);
-		virtual PImportStream copyToMemory() = 0;
+			virtual PImportStream copyToMemory();
 	};
+	
+} // namespace NMR
 
-}
-
-#endif // __NMR_IMPORTSTREAM_MEMORY
+#endif // __NMR_IMPORTSTREAM_UNIQUE_MEMORY

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -78,6 +78,8 @@ ${SRCS_COM}
 ./Source/Common/Platform/NMR_ExportStream_ZIP.cpp
 ./Source/Common/Platform/NMR_ImportStream_Callback.cpp
 ./Source/Common/Platform/NMR_ImportStream_Memory.cpp
+./Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
+./Source/Common/Platform/NMR_ImportStream_Shared_Memory.cpp
 ./Source/Common/Platform/NMR_ImportStream_ZIP.cpp
 ./Source/Common/Platform/NMR_PortableZIPWriter.cpp
 ./Source/Common/Platform/NMR_PortableZIPWriterEntry.cpp

--- a/Source/Common/Platform/NMR_ImportStream_GCC_Native.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_GCC_Native.cpp
@@ -32,7 +32,7 @@ This is an abstract base stream class for importing from streams with with std::
 --*/
 
 #include "Common/Platform/NMR_ImportStream_GCC_Native.h"
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 #include "Common/NMR_Exception.h"
 #include "Common/NMR_Exception_Windows.h"
 #include "Common/NMR_StringUtils.h"
@@ -155,7 +155,7 @@ namespace NMR {
 	PImportStream CImportStream_GCC_Native::copyToMemory()
 	{
 		nfUint64 cbStreamSize = retrieveSize();
-		return std::make_shared<CImportStream_Memory>(this, cbStreamSize, false);
+		return std::make_shared<CImportStream_Unique_Memory>(this, cbStreamSize, false);
 	}
 
 }

--- a/Source/Common/Platform/NMR_ImportStream_GCC_Win32.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_GCC_Win32.cpp
@@ -32,7 +32,7 @@ This is an abstract base stream class for importing from streams with GCC on Win
 --*/
 
 #include "Common/Platform/NMR_ImportStream_GCC_Win32.h"
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 #include "Common/NMR_Exception.h"
 
 #ifdef __GCC_WIN32
@@ -214,7 +214,7 @@ namespace NMR {
     {
 		nfUint64 cbStreamSize = retrieveSize();
 
-		return std::make_shared<CImportStream_Memory>(this, cbStreamSize, false);
+		return std::make_shared<CImportStream_Unique_Memory>(this, cbStreamSize, false);
 	}
 
 #endif // __GCC_WIN32

--- a/Source/Common/Platform/NMR_ImportStream_Memory.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Memory.cpp
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Abstract:
 
 NMR_ImportStream_Memory.cpp implements the CImportStream_Memory Class.
-This is a platform independent class for keeping data in a memory stream.
+This is an abstract platform independent class for keeping data in a memory stream.
 
 --*/
 
@@ -40,88 +40,6 @@ This is a platform independent class for keeping data in a memory stream.
 #include <string>
 
 namespace NMR {
-
-	CImportStream_Memory::CImportStream_Memory()
-	{
-		m_cbSize = 0;
-		m_nPosition = 0;
-	}
-
-
-	CImportStream_Memory::CImportStream_Memory(_In_ CImportStream * pStream, _In_ nfUint64 cbBytesToCopy, _In_ nfBool bNeedsToCopyAllBytes)
-	{
-		if (pStream == nullptr)
-			throw CNMRException(NMR_ERROR_INVALIDPARAM);
-
-		if (cbBytesToCopy > NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE)
-			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
-
-
-		// Retrieve Capacity and allocate buffer.
-		nfUint64 cbCapacity = cbBytesToCopy;
-		try {
-			m_Buffer.resize((size_t)cbCapacity);
-		}
-		catch (std::bad_alloc) {
-			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
-		}
-
-		m_cbSize = 0;
-		m_nPosition = 0;
-
-		while (m_cbSize < cbCapacity) {
-
-			// Only read in chunks
-			nfUint64 cbBytesToRead = cbCapacity - m_cbSize;
-			if (cbBytesToRead > NMR_IMPORTSTREAM_READCHUNKSIZE)
-				cbBytesToRead = NMR_IMPORTSTREAM_READCHUNKSIZE;
-
-			// Read bytes into memory
-			nfUint64 cbBytesRead;
-			cbBytesRead = pStream->readBuffer(&m_Buffer[(size_t) m_cbSize], cbBytesToRead, false);
-
-			// increase size
-			m_cbSize += cbBytesRead;
-
-			if (cbBytesRead != cbBytesToRead)
-				break;
-		}
-
-		if ((m_cbSize != cbCapacity) && (bNeedsToCopyAllBytes))
-			throw CNMRException(NMR_ERROR_COULDNOTREADFULLDATA);
-
-
-	}
-
-	CImportStream_Memory::CImportStream_Memory(_In_ const nfByte * pBuffer, _In_ nfUint64 cbBytes)
-	{
-		if (pBuffer == nullptr)
-			throw CNMRException(NMR_ERROR_INVALIDPARAM);
-
-		if (cbBytes > NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE)
-			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
-
-		// Retrieve Capacity and allocate buffer.
-		m_Buffer.resize((size_t) cbBytes);
-
-		m_cbSize = cbBytes;
-		m_nPosition = 0;
-
-		const nfByte * pSource = pBuffer;
-		nfByte * pTarget = &m_Buffer[0];
-
-		nfUint64 nIndex = cbBytes;
-		while (nIndex > 0) {
-			*pTarget = *pSource;
-
-			pSource++;
-			pTarget++;
-			nIndex--;
-		}		
-
-
-	}
-
 
 	CImportStream_Memory::~CImportStream_Memory()
 	{
@@ -182,7 +100,7 @@ namespace NMR {
 
 		if (cbBytesToRead > 0) {
 			nfUint64 nIndex = cbBytesToRead;
-			nfByte * pSource = &m_Buffer[(size_t)m_nPosition];
+			const nfByte * pSource = getAt(m_nPosition);
 			nfByte * pTarget = pBuffer;
 
 			while (nIndex > 0) {
@@ -215,15 +133,7 @@ namespace NMR {
 		std::string sUTF8FileName = fnUTF16toUTF8(pwszFileName);
 		PExportStream pExportStream = fnCreateExportStreamInstance(sUTF8FileName.c_str());
 		if (m_cbSize > 0) {
-			pExportStream->writeBuffer(&m_Buffer[0], m_cbSize);
+			pExportStream->writeBuffer(getAt(0), m_cbSize);
 		}
 	}
-
-	PImportStream CImportStream_Memory::copyToMemory()
-	{
-		__NMRASSERT(m_nPosition <= m_cbSize);
-
-		return std::make_shared<CImportStream_Memory>(this, m_cbSize - m_nPosition, true);
-	}
-
 }

--- a/Source/Common/Platform/NMR_ImportStream_Shared_Memory.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Shared_Memory.cpp
@@ -51,16 +51,16 @@ namespace NMR {
 
 		m_Buffer = pBuffer;
 	}	
-    
-    PImportStream CImportStream_Shared_Memory::copyToMemory()
+
+	PImportStream CImportStream_Shared_Memory::copyToMemory()
 	{
 		__NMRASSERT(m_nPosition <= m_cbSize);
 
 		return std::make_shared<CImportStream_Unique_Memory>(this, m_cbSize - m_nPosition, true);
 	}
 
-    __NMR_INLINE const nfByte * CImportStream_Shared_Memory::getAt(nfUint64 nPosition) { 
-        return &m_Buffer[nPosition]; 
-    }
+	__NMR_INLINE const nfByte * CImportStream_Shared_Memory::getAt(nfUint64 nPosition) { 
+		return &m_Buffer[nPosition]; 
+	}
 
 }

--- a/Source/Common/Platform/NMR_ImportStream_Shared_Memory.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Shared_Memory.cpp
@@ -26,43 +26,41 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Abstract:
 
-NMR_ImportStream_Memory.h defines the CImportStream_Memory Class.
-This is an abstract platform independent class for keeping data in a memory stream.
+NMR_ImportStream_Shared_Memory.cpp implements the CImportStream_Memory Class.
+This is a platform independent class for keeping data in a memory stream that doesn't own the wrapped buffer.
 
 --*/
 
-#ifndef __NMR_IMPORTSTREAM_MEMORY
-#define __NMR_IMPORTSTREAM_MEMORY
-
-#include "Common/Platform/NMR_ImportStream.h"
-#include "Common/NMR_Types.h"
-#include "Common/NMR_Local.h"
-
-#define NMR_IMPORTSTREAM_READCHUNKSIZE (1024*1024)
-
-#define NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE (1024ULL*1024ULL*1024ULL*1024ULL)
+#include "Common/Platform/NMR_ImportStream_Shared_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
+#include "Common/NMR_Exception.h"
+#include "Common/NMR_Exception_Windows.h"
 
 namespace NMR {
 
-	class CImportStream_Memory : public CImportStream {
-	protected:
-		nfUint64 m_cbSize;
-		nfUint64 m_nPosition;
-		
-		virtual const nfByte * getAt(nfUint64 nPosition) = 0;
-	public:
-		virtual ~CImportStream_Memory();
+	CImportStream_Shared_Memory::CImportStream_Shared_Memory(_In_ const nfByte * pBuffer, _In_ nfUint64 cbBytes)
+	{
+		if (pBuffer == nullptr)
+			throw CNMRException(NMR_ERROR_INVALIDPARAM);
 
-		virtual nfBool seekPosition(_In_ nfUint64 nPosition, _In_ nfBool bHasToSucceed);
-		virtual nfBool seekForward(_In_ nfUint64 cbBytes, _In_ nfBool bHasToSucceed);
-		virtual nfBool seekFromEnd(_In_ nfUint64 cbBytes, _In_ nfBool bHasToSucceed);
-		virtual nfUint64 getPosition();
-		virtual nfUint64 readBuffer(_In_ nfByte * pBuffer, _In_ nfUint64 cbTotalBytesToRead, nfBool bNeedsToReadAll);
-		virtual nfUint64 retrieveSize();
-		virtual void writeToFile(_In_ const nfWChar * pwszFileName);
-		virtual PImportStream copyToMemory() = 0;
-	};
+		if (cbBytes > NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE)
+			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
+
+		m_cbSize = cbBytes;
+		m_nPosition = 0;
+
+		m_Buffer = pBuffer;
+	}	
+    
+    PImportStream CImportStream_Shared_Memory::copyToMemory()
+	{
+		__NMRASSERT(m_nPosition <= m_cbSize);
+
+		return std::make_shared<CImportStream_Unique_Memory>(this, m_cbSize - m_nPosition, true);
+	}
+
+    __NMR_INLINE const nfByte * CImportStream_Shared_Memory::getAt(nfUint64 nPosition) { 
+        return &m_Buffer[nPosition]; 
+    }
 
 }
-
-#endif // __NMR_IMPORTSTREAM_MEMORY

--- a/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
@@ -58,7 +58,7 @@ namespace NMR {
 		try {
 			m_Buffer.resize((size_t)cbCapacity);
 		}
-		catch (std::bad_alloc) {
+		catch (std::bad_alloc&) {
 			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
 		}
 
@@ -126,5 +126,5 @@ namespace NMR {
     __NMR_INLINE const nfByte * CImportStream_Unique_Memory::getAt(nfUint64 nPosition) { 
         return &m_Buffer[nPosition]; 
     }
-	
+
 }

--- a/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
@@ -1,0 +1,130 @@
+/*++
+
+Copyright (C) 2018 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+NMR_ImportStream_Unique_Memory.cpp implements the CImportStream_Memory Class.
+This is a platform independent class for keeping data in a memory stream that owns the wrapped buffer.
+
+--*/
+
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
+#include "Common/NMR_Exception.h"
+#include "Common/NMR_Exception_Windows.h"
+
+namespace NMR {
+
+    CImportStream_Unique_Memory::CImportStream_Unique_Memory()
+	{
+		m_cbSize = 0;
+		m_nPosition = 0;
+	}
+
+
+	CImportStream_Unique_Memory::CImportStream_Unique_Memory(_In_ CImportStream * pStream, _In_ nfUint64 cbBytesToCopy, _In_ nfBool bNeedsToCopyAllBytes)
+	{
+		if (pStream == nullptr)
+			throw CNMRException(NMR_ERROR_INVALIDPARAM);
+
+		if (cbBytesToCopy > NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE)
+			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
+
+
+		// Retrieve Capacity and allocate buffer.
+		nfUint64 cbCapacity = cbBytesToCopy;
+		try {
+			m_Buffer.resize((size_t)cbCapacity);
+		}
+		catch (std::bad_alloc) {
+			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
+		}
+
+		m_cbSize = 0;
+		m_nPosition = 0;
+
+		while (m_cbSize < cbCapacity) {
+
+			// Only read in chunks
+			nfUint64 cbBytesToRead = cbCapacity - m_cbSize;
+			if (cbBytesToRead > NMR_IMPORTSTREAM_READCHUNKSIZE)
+				cbBytesToRead = NMR_IMPORTSTREAM_READCHUNKSIZE;
+
+			// Read bytes into memory
+			nfUint64 cbBytesRead;
+			cbBytesRead = pStream->readBuffer(&m_Buffer[(size_t) m_cbSize], cbBytesToRead, false);
+
+			// increase size
+			m_cbSize += cbBytesRead;
+
+			if (cbBytesRead != cbBytesToRead)
+				break;
+		}
+
+		if ((m_cbSize != cbCapacity) && (bNeedsToCopyAllBytes))
+			throw CNMRException(NMR_ERROR_COULDNOTREADFULLDATA);
+
+
+	}
+
+	CImportStream_Unique_Memory::CImportStream_Unique_Memory(_In_ const nfByte * pBuffer, _In_ nfUint64 cbBytes)
+	{
+		if (pBuffer == nullptr)
+			throw CNMRException(NMR_ERROR_INVALIDPARAM);
+
+		if (cbBytes > NMR_IMPORTSTREAM_MAXMEMSTREAMSIZE)
+			throw CNMRException(NMR_ERROR_INVALIDBUFFERSIZE);
+
+		// Retrieve Capacity and allocate buffer.
+		m_Buffer.resize((size_t) cbBytes);
+
+		m_cbSize = cbBytes;
+		m_nPosition = 0;
+
+		const nfByte * pSource = pBuffer;
+		nfByte * pTarget = &m_Buffer[0];
+
+		nfUint64 nIndex = cbBytes;
+		while (nIndex > 0) {
+			*pTarget = *pSource;
+
+			pSource++;
+			pTarget++;
+			nIndex--;
+		}
+	}	
+
+	PImportStream CImportStream_Unique_Memory::copyToMemory()
+	{
+		__NMRASSERT(m_nPosition <= m_cbSize);
+
+		return std::make_shared<CImportStream_Unique_Memory>(this, m_cbSize - m_nPosition, true);
+	}
+
+    __NMR_INLINE const nfByte * CImportStream_Unique_Memory::getAt(nfUint64 nPosition) { 
+        return &m_Buffer[nPosition]; 
+    }
+	
+}

--- a/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
@@ -37,7 +37,7 @@ This is a platform independent class for keeping data in a memory stream that ow
 
 namespace NMR {
 
-    CImportStream_Unique_Memory::CImportStream_Unique_Memory()
+	CImportStream_Unique_Memory::CImportStream_Unique_Memory()
 	{
 		m_cbSize = 0;
 		m_nPosition = 0;
@@ -123,8 +123,8 @@ namespace NMR {
 		return std::make_shared<CImportStream_Unique_Memory>(this, m_cbSize - m_nPosition, true);
 	}
 
-    __NMR_INLINE const nfByte * CImportStream_Unique_Memory::getAt(nfUint64 nPosition) { 
-        return &m_Buffer[nPosition]; 
-    }
+	__NMR_INLINE const nfByte * CImportStream_Unique_Memory::getAt(nfUint64 nPosition) { 
+		return &m_Buffer[nPosition]; 
+	}
 
 }

--- a/Source/Common/Platform/NMR_ImportStream_ZIP.cpp
+++ b/Source/Common/Platform/NMR_ImportStream_ZIP.cpp
@@ -32,7 +32,7 @@ This is a stream class for importing from a libZIP object.
 --*/
 
 #include "Common/Platform/NMR_ImportStream_ZIP.h"
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 #include "Common/NMR_Exception.h"
 #include "Common/NMR_Exception_Windows.h"
 #include <math.h>
@@ -126,7 +126,7 @@ namespace NMR {
 	{
 		nfUint64 cbStreamSize = retrieveSize();
 
-		return std::make_shared<CImportStream_Memory>(this, cbStreamSize, false);
+		return std::make_shared<CImportStream_Unique_Memory>(this, cbStreamSize, false);
 	}
 
 

--- a/Source/Model/COM/NMR_COMInterface_Model.cpp
+++ b/Source/Model/COM/NMR_COMInterface_Model.cpp
@@ -54,7 +54,7 @@ COM Interface Implementation for Model Class
 #include "Common/NMR_Exception.h"
 #include "Common/NMR_StringUtils.h"
 #include "Common/NMR_Exception_Windows.h"
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 
 #include "Model/Reader/NMR_ModelReader_3MF_Native.h"
 #include "Model/Writer/NMR_ModelWriter_3MF_Native.h"
@@ -1221,7 +1221,7 @@ namespace NMR {
 			if (pwszRelationShipType == nullptr)
 				throw CNMRException(NMR_ERROR_INVALIDPARAM);
 
-			PImportStream pStream = std::make_shared<CImportStream_Memory> ();
+			PImportStream pStream = std::make_shared<CImportStream_Unique_Memory> ();
 			PModelAttachment pAttachment = m_pModel->addAttachment(fnUTF16toUTF8(pwszURI), fnUTF16toUTF8(pwszRelationShipType), pStream);
 
 			CCOMObject<CCOMModelAttachment> * pCOMObject = new CCOMObject<CCOMModelAttachment>();
@@ -1251,7 +1251,7 @@ namespace NMR {
 			if (pszRelationShipType == nullptr)
 				throw CNMRException(NMR_ERROR_INVALIDPARAM);
 
-			PImportStream pStream = std::make_shared<CImportStream_Memory>();
+			PImportStream pStream = std::make_shared<CImportStream_Unique_Memory>();
 			PModelAttachment pAttachment = m_pModel->addAttachment(pszURI, pszRelationShipType, pStream);
 
 			CCOMObject<CCOMModelAttachment> * pCOMObject = new CCOMObject<CCOMModelAttachment>();

--- a/Source/Model/COM/NMR_COMInterface_ModelAttachment.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelAttachment.cpp
@@ -38,7 +38,7 @@ COM Interface Implementation for Model Classes
 #include "Common/NMR_Exception_Windows.h"
 #include "Common/NMR_StringUtils.h"
 
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 
 namespace NMR {
 
@@ -553,7 +553,7 @@ namespace NMR {
 			if (pBuffer == nullptr)
 				throw CNMRException(NMR_ERROR_INVALIDPOINTER);
 
-			PImportStream pImportStream = std::make_shared<CImportStream_Memory>(pBuffer, cbBufferSize);
+			PImportStream pImportStream = std::make_shared<CImportStream_Unique_Memory>(pBuffer, cbBufferSize);
 			m_pModelAttachment->setStream(pImportStream);
 
 			return handleSuccess();

--- a/Source/Model/COM/NMR_COMInterface_ModelReader.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelReader.cpp
@@ -35,7 +35,7 @@ COM Interface Implementation for Model Reader Class
 #include "Common/NMR_Exception_Windows.h" 
 #include "Common/Platform/NMR_Platform.h" 
 #include "Common/NMR_StringUtils.h" 
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Shared_Memory.h"
 #include "Common/Platform/NMR_ImportStream_Callback.h" 
 #include <locale.h>
 
@@ -155,7 +155,7 @@ namespace NMR {
 			if (m_pModelReader.get() == nullptr)
 				throw CNMRException(NMR_ERROR_INVALIDREADEROBJECT);
 
-			PImportStream pStream = std::make_shared<CImportStream_Memory>(pBuffer, cbBufferSize);
+			PImportStream pStream = std::make_shared<CImportStream_Shared_Memory>(pBuffer, cbBufferSize);
 			m_pModelReader->readStream(pStream);
 			return handleSuccess();
 		}

--- a/Source/Model/COM/NMR_COMInterface_ModelTexture2D.cpp
+++ b/Source/Model/COM/NMR_COMInterface_ModelTexture2D.cpp
@@ -39,7 +39,7 @@ COM Interface Implementation for Model Classes
 #include "Common/NMR_Exception_Windows.h"
 #include "Common/NMR_StringUtils.h"
 
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 #include "Model/Classes/NMR_ModelConstants.h"
 
 namespace NMR {
@@ -730,7 +730,7 @@ namespace NMR {
 			CModelTexture2DResource * pTextureResource = getTexture2D();
 			__NMRASSERT(pTextureResource);
 
-			PImportStream pImportStream = std::make_shared<CImportStream_Memory>(pBuffer, cbBufferSize);
+			PImportStream pImportStream = std::make_shared<CImportStream_Unique_Memory>(pBuffer, cbBufferSize);
 
 			CModel * pModel = pTextureResource->getModel();
 			__NMRASSERT(pModel);

--- a/Source/Model/Classes/NMR_Model.cpp
+++ b/Source/Model/Classes/NMR_Model.cpp
@@ -52,7 +52,7 @@ A model is an in memory representation of the 3MF file.
 #include "Model/Reader/Slice1507/NMR_ModelReader_Slice1507_SliceRefModel.h"
 #include "Common/Platform/NMR_XmlReader.h"
 #include "Common/Platform/NMR_Platform.h"
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 
 #include "Common/NMR_StringUtils.h" 
 namespace NMR {
@@ -641,7 +641,7 @@ namespace NMR {
 
 	PModelAttachment CModel::addPackageThumbnail()
 	{
-		return addPackageThumbnail(PACKAGE_THUMBNAIL_URI_BASE + std::string("/") + "thumbnail.png", std::make_shared<CImportStream_Memory>());
+		return addPackageThumbnail(PACKAGE_THUMBNAIL_URI_BASE + std::string("/") + "thumbnail.png", std::make_shared<CImportStream_Unique_Memory>());
 	}
 
 	void CModel::removePackageThumbnail()

--- a/Source/Model/Writer/NMR_ModelWriter_3MF_Native.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_3MF_Native.cpp
@@ -42,7 +42,7 @@ using LibZ and a native XML writer implementation.
 #include "Common/NMR_Exception.h" 
 #include "Common/Platform/NMR_XmlWriter.h" 
 #include "Common/Platform/NMR_XmlWriter_Native.h" 
-#include "Common/Platform/NMR_ImportStream_Memory.h"
+#include "Common/Platform/NMR_ImportStream_Unique_Memory.h"
 #include "Common/Platform/NMR_ExportStream_Memory.h"
 #include "Common/NMR_StringUtils.h" 
 #include "Common/3MF_ProgressMonitor.h"
@@ -168,7 +168,7 @@ namespace NMR {
 					PXmlWriter_Native pXMLWriter = std::make_shared<CXmlWriter_Native>(p);
 					writeSlicestackStream(pXMLWriter.get(), pModel, pSliceStackResource);
 
-					PImportStream pStream = std::make_shared<CImportStream_Memory>(p->getData(), p->getDataSize());
+					PImportStream pStream = std::make_shared<CImportStream_Unique_Memory>(p->getData(), p->getDataSize());
 					// check, whether that's already in here
 					PModelAttachment pSliceRefAttachment = m_pModel->findModelAttachment(pSliceStackResource->sliceRefPath());
 					if (pSliceRefAttachment.get() != nullptr) {


### PR DESCRIPTION
With the current implementation of CImportStream_Memory it is not possible to reuse memory from the user supplied buffer, as it is implemented with a std::vector, which shall own its own memory. Apart from this detail, the CImportStream_Memory implementation does not require to use std::vector, as it is only accessed via indexing, which is also supported by a raw const nfByte *, which is the original type of the buffer parameter.

To support memory sharing I have subclassed CImportStream_Memory with CImportStream_Shared_Memory and CImportStream_Unique_Memory. The CImportStream_Memory is now an abstract class that manages the position of the memory being read. The CImportStream_Unique_Memory implemented the stream as the old CImportStream_Memory, with a std::vector. The CImportStream_Shared_Memory keeps the memory as a const nfByte * which is taken directly from the constructor and it is not responsible for releasing it.

All the old uses of CImportStream_Memory now uses CImportStream_Unique_Memory except the CCOMModelReader, which uses CImportStream_Shared_Memory.

Issue solved: #119