### PR TITLE
Fix mingw-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - os: osx
       osx_image: xcode7.2
     - os: linux
+      dist: trusty
       compiler: x86_64-w64-mingw32-g++
       env: BUILDMODE=cmake-mingw32
       addons:


### PR DESCRIPTION
It appears that
1. travis sometimes uses other than the default linux distribution (trusty, 14.04) specified here:
https://docs.travis-ci.com/user/reference/overview/#linux
2. the default setup of mingw on xenial (16.04) has trouble with std::mutex, which is why lib3mf builds fail on this machine.

Thus, this commit enforces trusty as distribution for the mandatory mingw-builds.