### PR TITLE
libFuzzer + Fuzzit Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build
 build_32bit
 lib3MF.pc
 Include/Model/COM/NMR_COMVersion.h
+
+# Clion
+.idea
+cmake-build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,14 @@
 cmake_minimum_required (VERSION 3.0.2)
 
+# Specify search path for CMake modules to be loaded by include()
+# and find_package()
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Add defaults for cmake
+# Those need to be set before the project() call.
+include(DefineCompilerFlags REQUIRED)
+
+
 IF (NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} LESS 3.1)
   cmake_policy(SET CMP0054 OLD)
 ENDIF ()
@@ -10,6 +19,7 @@ ENDIF ()
 # increase patch version on every change that does not alter the API
 project (lib3MF
 	VERSION 1.8.1
+	LANGUAGES CXX C
 	DESCRIPTION "Lib3MF is a C++ implementation of the 3D Manufacturing Format file standard.")
 
 include(GNUInstallDirs)
@@ -156,6 +166,16 @@ message("LIB3MF_TESTS ... " ${LIB3MF_TESTS})
 if(LIB3MF_TESTS)
 	include(CTest)
 	add_subdirectory(UnitTests)
+endif()
+
+option(LIB3MF_FUZZ "Switch whether the fuzzers of Lib3MF should be build" OFF)
+message("LIB3MF_FUZZ ... " ${LIB3MF_FUZZ})
+if(LIB3MF_FUZZ)
+	if (NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_BUILD_TYPE MATCHES "AddressSanitizer"))
+			message(FATAL_ERROR "You need to build with Clang and AddressSanitizer for fuzzers to compile"
+					"Use export CC=clang; export CXX=clang++; and -DCMAKE_BUILD_TYPE=AddressSanitizer")
+	endif()
+	add_subdirectory(Fuzz)
 endif()
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,12 @@ A new folder `build` is created and contains projects for the IDE/build target y
 		1. navigate to the `build`-folder 
 		2. Call `make` to build the projects
 		3. Run/debug a project 
+
+## Building Fuzzers for lib3mf
+```bash
+mkdir build
+cd build
+cmake -DLIB3MF_FUZZ=on  -DCMAKE_BUILD_TYPE=AddressSanitizer ..
+make -j4
+./Fuzz/Fuzz_ReadFromBuffer
+```

--- a/Fuzz/CMakeLists.txt
+++ b/Fuzz/CMakeLists.txt
@@ -1,0 +1,15 @@
+macro(fuzzer name)
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../Include)
+    add_executable(${name} ${name}.cpp)
+    set_target_properties(${name}
+            PROPERTIES
+            COMPILE_FLAGS "-fsanitize=fuzzer"
+            LINK_FLAGS "-fsanitize=fuzzer")
+    target_include_directories(${name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../Include)
+    target_link_libraries(${name}
+            PRIVATE
+            ${PROJECT_NAME}_s
+            )
+endmacro()
+
+fuzzer(Fuzz_ReadFromBuffer)

--- a/Fuzz/Fuzz_ReadFromBuffer.cpp
+++ b/Fuzz/Fuzz_ReadFromBuffer.cpp
@@ -1,0 +1,592 @@
+/*++
+
+Copyright (C) 2018 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL MICROSOFT AND/OR NETFABB BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+ExtractInfo.cpp : 3MF Read Example
+
+--*/
+
+#ifndef __GNUC__
+#include <tchar.h>
+#include <Windows.h>
+#endif // __GNUC__
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+// Plain C Includes of 3MF Library
+#include "Model/COM/NMR_DLLInterfaces.h"
+
+// Use NMR namespace for the interfaces
+using namespace NMR;
+
+
+HRESULT ShowObjectProperties(_In_ PLib3MFModelObjectResource * pObject)
+{
+    HRESULT hResult;
+    DWORD nNeededChars;
+    std::vector<char> pBuffer;
+    std::string sName;
+    std::string sPartNumber;
+
+    // Retrieve Mesh Name Length
+    hResult = lib3mf_object_getnameutf8(pObject, NULL, 0, &nNeededChars);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    // Retrieve Mesh Name
+    if (nNeededChars > 0) {
+        pBuffer.resize(nNeededChars + 1);
+        hResult = lib3mf_object_getnameutf8(pObject, &pBuffer[0], nNeededChars + 1, NULL);
+        pBuffer[nNeededChars] = 0;
+        sName = std::string(&pBuffer[0]);
+    }
+
+    // Retrieve Mesh Part Number Length
+    hResult = lib3mf_object_getpartnumberutf8(pObject, NULL, 0, &nNeededChars);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    // Retrieve Mesh Name
+    if (nNeededChars > 0) {
+        pBuffer.resize(nNeededChars + 1);
+        hResult = lib3mf_object_getpartnumberutf8(pObject, &pBuffer[0], nNeededChars + 1, NULL);
+        pBuffer[nNeededChars] = 0;
+        sPartNumber = std::string(&pBuffer[0]);
+    }
+
+    // Output Object type
+    DWORD ObjectType;
+    hResult = lib3mf_object_gettype(pObject, &ObjectType);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    switch (ObjectType) {
+        case MODELOBJECTTYPE_MODEL:
+            break;
+        case MODELOBJECTTYPE_SUPPORT:
+            break;
+        case MODELOBJECTTYPE_SOLIDSUPPORT:
+            break;
+        case MODELOBJECTTYPE_OTHER:
+            break;
+        default:
+            break;
+
+    }
+
+
+    return LIB3MF_OK;
+}
+
+
+
+HRESULT ShowMeshObjectInformation(_In_ PLib3MFModelMeshObject * pMeshObject, _In_ PLib3MFModel * pModel)
+{
+    HRESULT hResult;
+    DWORD nVertexCount, nTriangleCount, nBeamCount, nSliceCount = 0;
+    DWORD nBeamSetCount;
+    BOOL bHasRepresentation;
+    DWORD nRepresentationMesh, nClippingMesh;
+    eModelBeamLatticeClipMode nClipMode;
+
+    hResult = ShowObjectProperties(pMeshObject);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    // Retrieve Mesh Vertex Count
+    hResult = lib3mf_meshobject_getvertexcount(pMeshObject, &nVertexCount);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    // Retrieve Mesh Triangle Count
+    hResult = lib3mf_meshobject_gettrianglecount(pMeshObject, &nTriangleCount);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    // Retrieve Mesh Beam Count
+    hResult = lib3mf_meshobject_getbeamcount(pMeshObject, &nBeamCount);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    if (nBeamCount > 0) {
+        hResult = lib3mf_meshobject_getbeamsetcount(pMeshObject, &nBeamSetCount);
+        if (hResult != LIB3MF_OK)
+            return hResult;
+        hResult = lib3mf_meshobject_getbeamlattice_representation(pMeshObject, &bHasRepresentation, &nRepresentationMesh);
+        if (hResult != LIB3MF_OK)
+            return hResult;
+        hResult = lib3mf_meshobject_getbeamlattice_clipping(pMeshObject, &nClipMode, &nClippingMesh);
+        if (hResult != LIB3MF_OK)
+            return hResult;
+    }
+
+
+    DWORD nSliceStackId;
+    hResult = lib3mf_meshobject_getslicestackid(pMeshObject, &nSliceStackId);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    DWORD nTotalPolygons = 0;
+    if (nSliceStackId > 0) {
+        PLib3MFSliceStack *pSliceStack;
+        hResult = lib3mf_model_getslicestackById(pModel, nSliceStackId, &pSliceStack);
+        if (hResult != LIB3MF_OK)
+            return hResult;
+        hResult = lib3mf_slicestack_getslicecount(pSliceStack, &nSliceCount);
+        if (hResult != LIB3MF_OK)
+            return hResult;
+        for (DWORD iSlice = 0; iSlice < nSliceCount; iSlice++) {
+            PLib3MFSlice *pSlice;
+            hResult = lib3mf_slicestack_getslice(pSliceStack, iSlice, &pSlice);
+            if (hResult != LIB3MF_OK)
+                return hResult;
+            DWORD nPolygonCount;
+            hResult = lib3mf_slice_getpolygoncount(pSlice, &nPolygonCount);
+            if (hResult != LIB3MF_OK)
+                return hResult;
+            for (DWORD polInd = 0; polInd < nPolygonCount; polInd++) {
+                DWORD nPolygonIndexCount;
+                hResult = lib3mf_slice_getpolygonindexcount(pSlice, polInd, &nPolygonIndexCount);
+                if (hResult != LIB3MF_OK)
+                    return hResult;
+                nTotalPolygons += nPolygonIndexCount;
+                std::vector<DWORD> vctPoldIndices(nPolygonIndexCount);
+                hResult = lib3mf_slice_getpolygonindices(pSlice, polInd, &vctPoldIndices[0], nPolygonIndexCount);
+                if (hResult != LIB3MF_OK)
+                    return hResult;
+            }
+        }
+    }
+
+    return LIB3MF_OK;
+}
+
+HRESULT ShowComponentsObjectInformation(_In_ PLib3MFModelComponentsObject * pComponentsObject)
+{
+    HRESULT hResult;
+    hResult = ShowObjectProperties(pComponentsObject);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+    // Retrieve Component
+    DWORD nComponentCount;
+    DWORD nIndex;
+    hResult = lib3mf_componentsobject_getcomponentcount(pComponentsObject, &nComponentCount);
+    if (hResult != LIB3MF_OK)
+        return hResult;
+
+
+    for (nIndex = 0; nIndex < nComponentCount; nIndex++) {
+        DWORD nResourceID;
+        PLib3MFModelComponent * pComponent;
+        hResult = lib3mf_componentsobject_getcomponent(pComponentsObject, nIndex, &pComponent);
+        if (hResult != LIB3MF_OK) {
+            return hResult;
+        }
+
+        hResult = lib3mf_component_getobjectresourceid(pComponent, &nResourceID);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pComponent);
+            return hResult;
+        }
+
+        BOOL bHasTransform;
+        hResult = lib3mf_component_hastransform(pComponent, &bHasTransform);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pComponent);
+            return hResult;
+        }
+
+        if (bHasTransform) {
+            MODELTRANSFORM Transform;
+
+            // Retrieve Transform
+            hResult = lib3mf_component_gettransform(pComponent, &Transform);
+            if (hResult != LIB3MF_OK) {
+                lib3mf_release(pComponent);
+                return hResult;
+            }
+
+        }
+
+    }
+
+    return LIB3MF_OK;
+}
+
+
+HRESULT ShowMetaDataInformation(_In_ PLib3MFModel * pModel)
+{
+    HRESULT hResult;
+    DWORD nMetaCount;
+
+    hResult = lib3mf_model_getmetadatacount(pModel, &nMetaCount);
+    if (hResult != LIB3MF_OK) {
+        return -1;
+    }
+
+    for (DWORD iMeta = 0; iMeta < nMetaCount; iMeta++) {
+        std::string sMetaDataKey;
+        std::string sMetaDataValue;
+        DWORD nNeededChars;
+        hResult = lib3mf_model_getmetadatakeyutf8(pModel, iMeta, NULL, 0, &nNeededChars);
+        if (hResult != LIB3MF_OK) {
+            return hResult;
+        }
+        // Retrieve Mesh Name
+        if (nNeededChars > 0) {
+            std::vector<char> pBuffer;
+            pBuffer.resize(nNeededChars + 1);
+            hResult = lib3mf_model_getmetadatakeyutf8(pModel, iMeta, &pBuffer[0], nNeededChars + 1, NULL);
+            if (hResult != LIB3MF_OK) {
+                return hResult;
+            }
+            pBuffer[nNeededChars] = 0;
+            sMetaDataKey = std::string(&pBuffer[0]);
+        }
+
+        hResult = lib3mf_model_getmetadatavalueutf8(pModel, iMeta, NULL, 0, &nNeededChars);
+        if (hResult != LIB3MF_OK) {
+            return hResult;
+        }
+        // Retrieve Mesh Name
+        if (nNeededChars > 0) {
+            std::vector<char> pBuffer;
+            pBuffer.resize(nNeededChars + 1);
+            hResult = lib3mf_model_getmetadatavalueutf8(pModel, iMeta, &pBuffer[0], nNeededChars + 1, NULL);
+            if (hResult != LIB3MF_OK) {
+                return hResult;
+            }
+            pBuffer[nNeededChars] = 0;
+            sMetaDataValue = std::string(&pBuffer[0]);
+        }
+    }
+    return LIB3MF_OK;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{
+    // General Variables
+    HRESULT hResult;
+    DWORD nInterfaceVersionMajor, nInterfaceVersionMinor, nInterfaceVersionMicro;
+    BOOL pbHasNext;
+    DWORD nWarningCount, nErrorCode, nNeededChars;
+    LPCSTR pszErrorMessage;
+
+    // Objects
+    PLib3MFModel * pModel;
+    PLib3MFModelReader * p3MFReader;
+    PLib3MFModelBuildItemIterator * pBuildItemIterator;
+    PLib3MFModelResourceIterator * pResourceIterator;
+
+
+
+    // Check 3MF Library Version
+    hResult = lib3mf_getinterfaceversion(&nInterfaceVersionMajor, &nInterfaceVersionMinor, &nInterfaceVersionMicro);
+    if (hResult != LIB3MF_OK) {
+        return -1;
+    }
+
+    if ((nInterfaceVersionMajor != NMR_APIVERSION_INTERFACE_MAJOR)) {
+        return -1;
+    }
+    if (!(nInterfaceVersionMinor >= NMR_APIVERSION_INTERFACE_MINOR)) {
+        return -1;
+    }
+
+    // Create Model Instance
+    hResult = lib3mf_createmodel(&pModel);
+    if (hResult != LIB3MF_OK) {
+        return -1;
+    }
+
+    // Create Model Reader
+    hResult = lib3mf_model_queryreader(pModel, "3mf", &p3MFReader);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_getlasterror(pModel, &nErrorCode, &pszErrorMessage);
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    // And deactivate the strict mode (default is "false", anyway. This just demonstrates where/how to use it).
+    hResult = lib3mf_reader_setstrictmodeactive(p3MFReader, false);
+
+    // Import Model from 3MF File
+    bool bErrorOnRead = false;
+    hResult = lib3mf_reader_readfrombuffer(p3MFReader, (BYTE*) Data, Size);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_getlasterror(p3MFReader, &nErrorCode, &pszErrorMessage);
+        // don't abort right away
+        bErrorOnRead = true;
+    }
+
+    // Check warnings in any case:
+    hResult = lib3mf_reader_getwarningcount(p3MFReader, &nWarningCount);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_release(p3MFReader);
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    for (DWORD iWarning = 0; iWarning < nWarningCount; iWarning++) {
+        hResult = lib3mf_reader_getwarningutf8(p3MFReader, iWarning, &nErrorCode, NULL, 0, &nNeededChars);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(p3MFReader);
+            lib3mf_release(pModel);
+            return hResult;
+        }
+
+        std::string sWarning;
+        sWarning.resize(nNeededChars + 1);
+        hResult = lib3mf_reader_getwarningutf8(p3MFReader, iWarning, &nErrorCode, &sWarning[0], nNeededChars + 1, NULL);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(p3MFReader);
+            lib3mf_release(pModel);
+            return hResult;
+        }
+        // Insert custom warning handling here
+    }
+
+    // Finally stop if we had an error on read
+    if (bErrorOnRead) {
+        lib3mf_release(p3MFReader);
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    // Release model reader
+    lib3mf_release(p3MFReader);
+
+
+    // get metadata
+    hResult = ShowMetaDataInformation(pModel);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    // Iterate through all the Objects
+    hResult = lib3mf_model_getobjects(pModel, &pResourceIterator);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    hResult = lib3mf_resourceiterator_movenext(pResourceIterator, &pbHasNext);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_release(pResourceIterator);
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    while (pbHasNext) {
+        PLib3MFModelResource * pResource;
+        PLib3MFModelMeshObject * pMeshObject;
+        PLib3MFModelComponentsObject * pComponentsObject;
+        ModelResourceID ResourceID;
+
+        // get current resource
+        hResult = lib3mf_resourceiterator_getcurrent(pResourceIterator, &pResource);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pResourceIterator);
+            lib3mf_release(pModel);
+            return -1;
+        }
+
+        // get resource ID
+        hResult = lib3mf_resource_getresourceid(pResource, &ResourceID);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pResource);
+            lib3mf_release(pResourceIterator);
+            lib3mf_release(pModel);
+            return -1;
+        }
+
+        // Query mesh interface
+        BOOL bIsMeshObject;
+        hResult = lib3mf_object_ismeshobject(pResource, &bIsMeshObject);
+        if ((hResult == LIB3MF_OK) && (bIsMeshObject)) {
+
+            pMeshObject = pResource;
+
+            // Show Mesh Object Information
+            hResult = ShowMeshObjectInformation(pMeshObject, pModel);
+            if (hResult != LIB3MF_OK) {
+                lib3mf_release(pResource);
+                lib3mf_release(pResourceIterator);
+                lib3mf_release(pModel);
+                return -1;
+            }
+        }
+
+
+        // Query component interface
+        BOOL bIsComponentsObject;
+        hResult = lib3mf_object_iscomponentsobject(pResource, &bIsComponentsObject);
+        if ((hResult == LIB3MF_OK) && (bIsComponentsObject)) {
+
+            pComponentsObject = (PLib3MFModelComponentsObject*)pResource;
+
+            // Show Component Object Information
+            hResult = ShowComponentsObjectInformation(pComponentsObject);
+            if (hResult != LIB3MF_OK) {
+                lib3mf_release(pResource);
+                lib3mf_release(pResourceIterator);
+                lib3mf_release(pModel);
+                return -1;
+            }
+        }
+
+        // free instances
+        lib3mf_release(pResource);
+
+        hResult = lib3mf_resourceiterator_movenext(pResourceIterator, &pbHasNext);
+        if (hResult != LIB3MF_OK) {
+            return -1;
+        }
+    }
+
+    // Release Resource Iterator
+    lib3mf_release(pResourceIterator);
+
+
+    // Iterate through all the Build items
+    hResult = lib3mf_model_getbuilditems(pModel, &pBuildItemIterator);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_release(pBuildItemIterator);
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    hResult = lib3mf_builditemiterator_movenext(pBuildItemIterator, &pbHasNext);
+    if (hResult != LIB3MF_OK) {
+        lib3mf_release(pBuildItemIterator);
+        lib3mf_release(pModel);
+        return -1;
+    }
+
+    while (pbHasNext) {
+
+        DWORD ResourceID;
+        MODELTRANSFORM Transform;
+        PLib3MFModelBuildItem * pBuildItem;
+        // Retrieve Build Item
+        hResult = lib3mf_builditemiterator_getcurrent(pBuildItemIterator, &pBuildItem);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pBuildItemIterator);
+            lib3mf_release(pModel);
+            return -1;
+        }
+
+        // Retrieve Resource
+        PLib3MFModelObjectResource * pObjectResource;
+        hResult = lib3mf_builditem_getobjectresource(pBuildItem, &pObjectResource);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pBuildItem);
+            lib3mf_release(pBuildItemIterator);
+            lib3mf_release(pModel);
+            return -1;
+        }
+
+        // Retrieve Resource ID
+        hResult = lib3mf_resource_getresourceid(pObjectResource, &ResourceID);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pObjectResource);
+            lib3mf_release(pBuildItem);
+            lib3mf_release(pBuildItemIterator);
+            lib3mf_release(pModel);
+            return -1;
+        }
+
+        // Release Object Resource ID
+        lib3mf_release(pObjectResource);
+
+
+        // Check Object Transform
+        BOOL bHasTransform;
+        hResult = lib3mf_builditem_hasobjecttransform(pBuildItem, &bHasTransform);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pBuildItem);
+            lib3mf_release(pBuildItemIterator);
+            lib3mf_release(pModel);
+            return -1;
+        }
+
+        if (bHasTransform) {
+            // Retrieve Transform
+            hResult = lib3mf_builditem_getobjecttransform(pBuildItem, &Transform);
+            if (hResult != LIB3MF_OK) {
+                lib3mf_release(pBuildItem);
+                lib3mf_release(pBuildItemIterator);
+                lib3mf_release(pModel);
+                return -1;
+            }
+
+        }
+
+
+        // Retrieve Mesh Part Number Length
+        std::string sPartNumber;
+        DWORD nNeededChars;
+        hResult = lib3mf_builditem_getpartnumberutf8(pBuildItem, NULL, 0, &nNeededChars);
+        if (hResult != LIB3MF_OK) {
+            lib3mf_release(pBuildItem);
+            lib3mf_release(pBuildItemIterator);
+            lib3mf_release(pModel);
+            return hResult;
+        }
+
+        // Retrieve Mesh Name
+        if (nNeededChars > 0) {
+            std::vector<char> pBuffer;
+            pBuffer.resize(nNeededChars + 1);
+            hResult = lib3mf_builditem_getpartnumberutf8(pBuildItem, &pBuffer[0], nNeededChars + 1, NULL);
+            pBuffer[nNeededChars] = 0;
+            sPartNumber = std::string(&pBuffer[0]);
+        }
+
+        // Release Build Item
+        lib3mf_release(pBuildItem);
+
+        // Move to next Item
+        hResult = lib3mf_builditemiterator_movenext(pBuildItemIterator, &pbHasNext);
+        if (hResult != LIB3MF_OK) {
+            return -1;
+        }
+    }
+
+
+    // Release Build Item Iterator
+    lib3mf_release(pBuildItemIterator);
+
+    // Release Model
+    lib3mf_release(pModel);
+
+    return 0;
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # lib3mf
 [![Build Status](https://travis-ci.org/3MFConsortium/lib3mf.svg?branch=master)](https://travis-ci.org/3MFConsortium/lib3mf)
+[![Fuzzit Status](https://app.fuzzit.dev/badge?org_id=Bx6gSYcE8iMM5nhWY7iB&branch=master)](https://fuzzit.dev)
 
 Lib3MF is a C++ implementation of the 3D Manufacturing Format file standard.
 

--- a/cmake/DefineCompilerFlags.cmake
+++ b/cmake/DefineCompilerFlags.cmake
@@ -1,0 +1,14 @@
+
+if (UNIX AND NOT WIN32)
+    # Activate with: -DCMAKE_BUILD_TYPE=AddressSanitizer
+    set(CMAKE_C_FLAGS_ADDRESSSANITIZER "-g -O1 -fsanitize=address -fno-omit-frame-pointer"
+            CACHE STRING "Flags used by the C compiler during ADDRESSSANITIZER builds.")
+    set(CMAKE_CXX_FLAGS_ADDRESSSANITIZER "-g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=null"
+            CACHE STRING "Flags used by the CXX compiler during ADDRESSSANITIZER builds.")
+    set(CMAKE_SHARED_LINKER_FLAGS_ADDRESSSANITIZER "-fsanitize=address"
+            CACHE STRING "Flags used by the linker during the creation of shared libraries during ADDRESSSANITIZER builds.")
+    set(CMAKE_MODULE_LINKER_FLAGS_ADDRESSSANITIZER "-fsanitize=address"
+            CACHE STRING "Flags used by the linker during the creation of shared libraries during ADDRESSSANITIZER builds.")
+    set(CMAKE_EXEC_LINKER_FLAGS_ADDRESSSANITIZER "-fsanitize=address"
+            CACHE STRING "Flags used by the linker during ADDRESSSANITIZER builds.")
+endif()


### PR DESCRIPTION
This commit add the first fuzzer as well as the necessary changes
in the cmake build system. Also this adds an integration with
Fuzzit - Continuous Fuzzing as a service platform which will run
the fuzzers constanttly and update the latest version on a daily
basis.

Hi Team,

I've added libFuzzer targets as well as instruction to how to compile and run them.
Also, it seems that the UBSAN sanitizer found a minor bug - probably worth looking into this.
```text
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/local/opt/llvm/bin/../include/c++/v1/vector:1544:12 in 
MS: 0 ; base unit: 0000000000000000000000000000000000000000


artifact_prefix='./'; Test unit written to ./crash-da39a3ee5e6b4b0d3255bfef95601890afd80709
Base64: 
==73101== ERROR: libFuzzer: deadly signal
    #0 0x10b72fab7 in __sanitizer_print_stack_trace (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x6aab7)
    #1 0x1090c5c78 in fuzzer::PrintStackTrace() FuzzerUtil.cpp:206
    #2 0x1090a56f8 in fuzzer::Fuzzer::CrashCallback() FuzzerLoop.cpp:237
    #3 0x1090a56bf in fuzzer::Fuzzer::StaticCrashSignalCallback() FuzzerLoop.cpp:209
    #4 0x7fff7ebc7b5c in _sigtramp (libsystem_platform.dylib:x86_64+0x4b5c)
    #5 0x60200000018f  (<unknown module>)
    #6 0x7fff7ea816a5 in abort (libsystem_c.dylib:x86_64+0x5b6a5)
    #7 0x10b746505 in __sanitizer::Abort() (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x81505)
    #8 0x10b745e83 in __sanitizer::Die() (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x80e83)
    #9 0x10b753dc0 in __ubsan_handle_type_mismatch_v1_abort (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x8edc0)
    #10 0x108c9030d in std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::operator[](unsigned long) vector:1544
    #11 0x108c905ef in NMR::CImportStream_Memory::CImportStream_Memory(unsigned char const*, unsigned long long) NMR_ImportStream_Memory.cpp:111
    #12 0x108e6731a in std::__1::__compressed_pair_elem<NMR::CImportStream_Memory, 1, false>::__compressed_pair_elem<unsigned char*&, unsigned long long&, 0ul, 1ul>(std::__1::piecewise_construct_t, std::__1::tuple<unsigned char*&, unsigned long long&>, std::__1::__tuple_indices<0ul, 1ul>) memory:2156
    #13 0x108e66ec2 in std::__1::__compressed_pair<std::__1::allocator<NMR::CImportStream_Memory>, NMR::CImportStream_Memory>::__compressed_pair<std::__1::allocator<NMR::CImportStream_Memory>&, unsigned char*&, unsigned long long&>(std::__1::piecewise_construct_t, std::__1::tuple<std::__1::allocator<NMR::CImportStream_Memory>&>, std::__1::tuple<unsigned char*&, unsigned long long&>) memory:2259
    #14 0x108e6617c in std::__1::__shared_ptr_emplace<NMR::CImportStream_Memory, std::__1::allocator<NMR::CImportStream_Memory> >::__shared_ptr_emplace<unsigned char*&, unsigned long long&>(std::__1::allocator<NMR::CImportStream_Memory>, unsigned char*&&&, unsigned long long&&&) memory:3672
    #15 0x108e65ba8 in std::__1::shared_ptr<NMR::CImportStream_Memory> std::__1::shared_ptr<NMR::CImportStream_Memory>::make_shared<unsigned char*&, unsigned long long&>(unsigned char*&&&, unsigned long long&&&) memory:4331
    #16 0x108e5f5d5 in std::__1::enable_if<!(is_array<NMR::CImportStream_Memory>::value), std::__1::shared_ptr<NMR::CImportStream_Memory> >::type std::__1::make_shared<NMR::CImportStream_Memory, unsigned char*&, unsigned long long&>(unsigned char*&&&, unsigned long long&&&) memory:4710
    #17 0x108e5ef40 in NMR::CCOMModelReader::ReadFromBuffer(unsigned char*, unsigned long long) NMR_COMInterface_ModelReader.cpp:158
    #18 0x108b45508 in LLVMFuzzerTestOneInput Fuzz_ReadFromBuffer.cpp:342
    #19 0x1090a6ab8 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) FuzzerLoop.cpp:533
    #20 0x1090a8072 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, fuzzer::fuzzer_allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) FuzzerLoop.cpp:723
    #21 0x1090a8625 in fuzzer::Fuzzer::Loop(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, fuzzer::fuzzer_allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) FuzzerLoop.cpp:768
    #22 0x10909f4db in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) FuzzerDriver.cpp:760
    #23 0x1090c6f62 in main FuzzerMain.cpp:20
    #24 0x7fff7e9dc3d4 in start (libdyld.dylib:x86_64+0x163d4)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 0 ; base unit: 0000000000000000000000000000000000000000
```

Also I'll be happy to contribute free resources on [Fuzzit](https://fuzzit.dev) for continuous fuzzing. This will notify you if new bugs are found or new one are introduced in development. We work with some other great oss projects like [systemd](https://github.com/systemd/systemd), [apache-arrow](https://github.com/apache/arrow) and many others.
For this work I need a bit of help for someone to help set-up a daily cron-job on Travis and I'll add the necessary steps in this Pull-request.

CCing @martinweismann as I saw you commented on the latest PRs
