### PR TITLE
Fix IO for big-endian machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
       docker pull multiarch/qemu-user-static ;
       docker pull multiarch/ubuntu-debootstrap:powerpc-xenial ;
       docker run --rm --privileged multiarch/qemu-user-static --reset -p y ;
-      docker build -t ppc-xenial CI ;
+      docker build -t ppc-xenial -f CI/Dockerfile . ;
       fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,20 @@
 # to generate the build-status-icon in the main README.md-file.
 
 language: cpp
+sudo: required
+services:
+  - docker
 
 matrix:
   include:
     - os: linux
       compiler: gcc
+      env: BUILDMODE=cmake-make
     - os: osx
       osx_image: xcode7.2
+      env: BUILDMODE=cmake-make
+    - os: linux
+      env: BUILDMODE=ppcxenial
     - os: linux
       dist: trusty
       compiler: x86_64-w64-mingw32-g++
@@ -25,9 +32,16 @@ matrix:
             - g++-mingw-w64-x86-64
 
 before_script:
-    - if [[ "$BUILDMODE" = "cmake-mingw32" ]]; then sh cmake/GenerateMinGW.sh ; else sh cmake/GenerateMake.sh ; fi
-    - cd build
+    - if [[ "$BUILDMODE" = "cmake-mingw32" ]]; then sh cmake/GenerateMinGW.sh; cd build; fi
+    - if [[ "$BUILDMODE" = "cmake-make" ]]; then sh cmake/GenerateMake.sh; cd build; fi
+    - if [[ "$BUILDMODE" = "ppcxenial" ]]; then
+      docker pull multiarch/qemu-user-static ;
+      docker pull multiarch/ubuntu-debootstrap:powerpc-xenial ;
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p y ;
+      docker build -t ppc-xenial CI ;
+      fi
 
 script:
-    - cmake --build .
-    - if [[ "$BUILDMODE" != "cmake-mingw32" ]]; then ctest -V ; fi
+    - if [[ "$BUILDMODE" != "ppcxenial" ]]; then cmake --build . ; fi
+    - if [[ "$BUILDMODE" == "cmake-make" ]]; then ctest -V ; fi
+    - if [[ "$BUILDMODE" == "ppcxenial" ]]; then docker run ppc-xenial; fi

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,6 +1,6 @@
 FROM multiarch/ubuntu-debootstrap:powerpc-xenial
 RUN apt-get update
 RUN apt-get -y install git cmake g++
-ADD .. lib3mf-repo
-ADD script.sh ./script.sh
+ADD . lib3mf-repo
+ADD CI/script.sh script.sh
 ENTRYPOINT ["sh", "script.sh"]

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,6 +1,6 @@
 FROM multiarch/ubuntu-debootstrap:powerpc-xenial
 RUN apt-get update
 RUN apt-get -y install git cmake g++
-ADD .
+ADD . lib3mf-repo
 ADD script.sh ./script.sh
 ENTRYPOINT ["sh", "script.sh"]

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,4 +1,4 @@
-FROM martinweismann/lib3mf_ppcbuilds:testing
+FROM martinweismann/lib3mf_ppcbuilds:latest
 ADD . lib3mf-repo
 ADD CI/script.sh script.sh
 ENTRYPOINT ["sh", "script.sh"]

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,6 +1,4 @@
-FROM multiarch/ubuntu-debootstrap:powerpc-xenial
-RUN apt-get update
-RUN apt-get -y install git cmake g++
+FROM martinweismann/lib3mf_ppcbuilds:testing
 ADD . lib3mf-repo
 ADD CI/script.sh script.sh
 ENTRYPOINT ["sh", "script.sh"]

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,6 +1,6 @@
 FROM multiarch/ubuntu-debootstrap:powerpc-xenial
 RUN apt-get update
 RUN apt-get -y install git cmake g++
-ADD . lib3mf-repo
+ADD .. lib3mf-repo
 ADD script.sh ./script.sh
 ENTRYPOINT ["sh", "script.sh"]

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -1,0 +1,6 @@
+FROM multiarch/ubuntu-debootstrap:powerpc-xenial
+RUN apt-get update
+RUN apt-get -y install git cmake g++
+ADD .
+ADD script.sh ./script.sh
+ENTRYPOINT ["sh", "script.sh"]

--- a/CI/script.sh
+++ b/CI/script.sh
@@ -2,6 +2,9 @@
 
 ls -ahl
 pwd
+cd lib3mf-repo
+ls -ahl
+pwd
 git status
 sh cmake/GenerateMake.sh
 cd build

--- a/CI/script.sh
+++ b/CI/script.sh
@@ -1,12 +1,6 @@
 #!/bin/sh
 
-ls -ahl
-pwd
-cd lib3mf-repo
-ls -ahl
-pwd
-git status
 sh cmake/GenerateMake.sh
 cd build
-# cmake --build .
-# ctest -V .
+cmake --build .
+ctest -V .

--- a/CI/script.sh
+++ b/CI/script.sh
@@ -3,5 +3,5 @@
 cd lib3mf-repo
 sh cmake/GenerateMake.sh
 cd build
-cmake --build .
+make -j2
 ctest -V .

--- a/CI/script.sh
+++ b/CI/script.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+cd lib3mf-repo
 sh cmake/GenerateMake.sh
 cd build
 cmake --build .

--- a/CI/script.sh
+++ b/CI/script.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+ls -ahl
+pwd
+git status
+sh cmake/GenerateMake.sh
+cd build
+# cmake --build .
+# ctest -V .

--- a/Include/Common/MeshImport/NMR_MeshImporter_STL.h
+++ b/Include/Common/MeshImport/NMR_MeshImporter_STL.h
@@ -38,6 +38,7 @@ This is a derived class for Importing the binary STL and color STL Mesh Format.
 #include "Common/Math/NMR_Geometry.h" 
 #include "Common/Mesh/NMR_Mesh.h" 
 #include "Common/MeshImport/NMR_MeshImporter.h" 
+#include "Common/NMR_Architecture_Utils.h"
 
 #include <vector>
 
@@ -46,8 +47,17 @@ namespace NMR {
 #pragma pack (1)
 	typedef struct {
 		NVEC3 m_normal;
-		NVEC3 m_vertieces[3];
+		NVEC3 m_vertices[3];
 		nfUint16 m_attribute;
+		void swapByteOrder() {
+			m_attribute = swapBytes(m_attribute);
+			for (nfUint32 i = 0; i < 3; i++) {
+				m_normal.m_fields[i] = swapBytes(m_normal.m_fields[i]);
+				for (nfUint32 j = 0; j < 3; j++) {
+					m_vertices[i].m_fields[j] = swapBytes(m_vertices[i].m_fields[j]);
+				}
+			}
+		}
 	} MESHFORMAT_STL_FACET;
 #pragma pack()
 

--- a/Include/Common/NMR_Architecture_Utils.h
+++ b/Include/Common/NMR_Architecture_Utils.h
@@ -1,0 +1,66 @@
+/*++
+
+Copyright (C) 2019 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+NMR_Architecture_Utils.h defines helper functions for working on big-endian architecture
+
+--*/
+
+#ifndef __NMR_ARCHITECTURE_UTILS
+#define __NMR_ARCHITECTURE_UTILS
+
+#include "NMR_Types.h" 
+
+namespace NMR {
+
+	template<int N>
+	void swapBytesArray(unsigned char(&bytes)[N]) {
+		// Optimize this with a platform-specific API as desired.
+		for (unsigned char *p = bytes, *end = bytes + N - 1; p < end; ++p, --end) {
+			unsigned char tmp = *p;
+			*p = *end;
+			*end = tmp;
+		}
+	}
+	template<typename T>
+	T swapBytes(T value) {
+		swapBytesArray(*reinterpret_cast<unsigned char(*)[sizeof(value)]>(&value));
+		return value;
+	}
+
+	inline bool isBigEndian(void)
+	{
+		union {
+			nfUint32 i;
+			char c[4];
+		} bint = { 0x01020304 };
+
+		return bint.c[0] == 1;
+	}
+}
+
+#endif // __NMR_ARCHITECTURE_UTILS

--- a/Include/Common/Platform/NMR_PortableZIPWriterTypes.h
+++ b/Include/Common/Platform/NMR_PortableZIPWriterTypes.h
@@ -58,7 +58,35 @@ NMR_PortableZIPWriterTypes.h defines a portable and fast writer of ZIP files
 
 namespace NMR {
 
+	// helper functions for big-endian architecture
+
+	template<int N>
+	void swapBytesArray(unsigned char(&bytes)[N]) {
+		// Optimize this with a platform-specific API as desired.
+		for (unsigned char *p = bytes, *end = bytes + N - 1; p < end; ++p, --end) {
+			unsigned char tmp = *p;
+			*p = *end;
+			*end = tmp;
+		}
+	}
+	template<typename T>
+	T swapBytes(T value) {
+		swapBytesArray(*reinterpret_cast<unsigned char(*)[sizeof(value)]>(&value));
+		return value;
+	}
+
+	inline bool isBigEndian(void)
+	{
+		union {
+			uint32_t i;
+			char c[4];
+		} bint = { 0x01020304 };
+
+		return bint.c[0] == 1;
+	}
+
 #pragma pack (1)
+	
 
 	typedef struct {
 		nfUint32 m_nSignature;
@@ -72,12 +100,30 @@ namespace NMR {
 		nfUint32 m_nUnCompressedSize;
 		nfUint16 m_nFileNameLength;
 		nfUint16 m_nExtraFieldLength;
+		void swapByteOrder() {
+			m_nSignature = swapBytes(m_nSignature);
+			m_nVersion = swapBytes(m_nVersion);
+			m_nGeneralPurposeFlags = swapBytes(m_nGeneralPurposeFlags);
+			m_nCompressionMethod = swapBytes(m_nCompressionMethod);
+			m_nLastModTime = swapBytes(m_nLastModTime);
+			m_nLastModDate = swapBytes(m_nLastModDate);
+			m_nCRC32 = swapBytes(m_nCRC32);
+			m_nCompressedSize = swapBytes(m_nCompressedSize);
+			m_nUnCompressedSize = swapBytes(m_nUnCompressedSize);
+			m_nFileNameLength = swapBytes(m_nFileNameLength);
+			m_nExtraFieldLength = swapBytes(m_nExtraFieldLength);
+		}
 	} ZIPLOCALFILEHEADER;
 
 	typedef struct {
 		nfUint32 m_nCRC32;
 		nfUint32 m_nCompressedSize;
 		nfUint32 m_nUnCompressedSize;
+		void swapByteOrder() {
+			m_nCRC32 = swapBytes(m_nCRC32);
+			m_nCompressedSize = swapBytes(m_nCompressedSize);
+			m_nUnCompressedSize = swapBytes(m_nUnCompressedSize);
+		}
 	} ZIPLOCALFILEDESCRIPTOR;
 
 	typedef struct {
@@ -85,6 +131,12 @@ namespace NMR {
 		nfUint16 m_nFieldSize;
 		nfUint64 m_nUncompressedSize;
 		nfUint64 m_nCompressedSize;
+		void swapByteOrder() {
+			m_nTag = swapBytes(m_nTag);
+			m_nFieldSize = swapBytes(m_nFieldSize);
+			m_nUncompressedSize = swapBytes(m_nUncompressedSize);
+			m_nCompressedSize = swapBytes(m_nCompressedSize);
+		}
 	} ZIP64EXTRAINFORMATIONFIELD;
 
 	typedef struct {
@@ -105,6 +157,25 @@ namespace NMR {
 		nfUint16 m_nInternalFileAttributes;
 		nfUint32 m_nExternalFileAttributes;
 		nfUint32 m_nRelativeOffsetOfLocalHeader;
+		void swapByteOrder() {
+			m_nSignature = swapBytes(m_nSignature);
+			m_nVersionMade = swapBytes(m_nVersionMade);
+			m_nVersionNeeded = swapBytes(m_nVersionNeeded);
+			m_nGeneralPurposeFlags = swapBytes(m_nGeneralPurposeFlags);
+			m_nCompressionMethod = swapBytes(m_nCompressionMethod);
+			m_nLastModTime = swapBytes(m_nLastModTime);
+			m_nLastModDate = swapBytes(m_nLastModDate);
+			m_nCRC32 = swapBytes(m_nCRC32);
+			m_nCompressedSize = swapBytes(m_nCompressedSize);
+			m_nUnCompressedSize = swapBytes(m_nUnCompressedSize);
+			m_nFileNameLength = swapBytes(m_nFileNameLength);
+			m_nExtraFieldLength = swapBytes(m_nExtraFieldLength);
+			m_nFileCommentLength = swapBytes(m_nFileCommentLength);
+			m_nDiskNumberStart = swapBytes(m_nDiskNumberStart);
+			m_nInternalFileAttributes = swapBytes(m_nInternalFileAttributes);
+			m_nExternalFileAttributes = swapBytes(m_nExternalFileAttributes);
+			m_nRelativeOffsetOfLocalHeader = swapBytes(m_nRelativeOffsetOfLocalHeader);
+		}
 	} ZIPCENTRALDIRECTORYFILEHEADER;
 
 	typedef struct {
@@ -116,6 +187,16 @@ namespace NMR {
 		nfUint32 m_nSizeOfCentralDirectory;
 		nfUint32 m_nOffsetOfCentralDirectory;
 		nfUint16 m_nCommentLength;
+		void swapByteOrder() {
+			m_nSignature = swapBytes(m_nSignature);
+			m_nNumberOfDisk = swapBytes(m_nNumberOfDisk);
+			m_nRelativeNumberOfDisk = swapBytes(m_nRelativeNumberOfDisk);
+			m_nNumberOfEntriesOfDisk = swapBytes(m_nNumberOfEntriesOfDisk);
+			m_nNumberOfEntriesOfDirectory = swapBytes(m_nNumberOfEntriesOfDirectory);
+			m_nSizeOfCentralDirectory = swapBytes(m_nSizeOfCentralDirectory);
+			m_nOffsetOfCentralDirectory = swapBytes(m_nOffsetOfCentralDirectory);
+			m_nCommentLength = swapBytes(m_nCommentLength);
+		}
 	} ZIPENDOFCENTRALDIRHEADER;
 
 	typedef struct {
@@ -130,6 +211,18 @@ namespace NMR {
 		nfUint64 m_nSizeOfCentralDirectory;
 		nfUint64 m_nOffsetOfCentralDirectoryWithRespectToDisk;
 		// zip64 extensible data sector, variable size; not used
+		void swapByteOrder() {
+			m_nSignature = swapBytes(m_nSignature);
+			m_nEndOfCentralDirHeaderRecord = swapBytes(m_nEndOfCentralDirHeaderRecord);
+			m_nVersionMade = swapBytes(m_nVersionMade);
+			m_nVersionNeeded = swapBytes(m_nVersionNeeded);
+			m_nNumberOfDisk = swapBytes(m_nNumberOfDisk);
+			m_nNumberOfDiskOfCentralDirectory = swapBytes(m_nNumberOfDiskOfCentralDirectory);
+			m_nTotalNumberOfEntriesOnThisDisk = swapBytes(m_nTotalNumberOfEntriesOnThisDisk);
+			m_nTotalNumberOfEntriesInCentralDirectory = swapBytes(m_nTotalNumberOfEntriesInCentralDirectory);
+			m_nSizeOfCentralDirectory = swapBytes(m_nSizeOfCentralDirectory);
+			m_nOffsetOfCentralDirectoryWithRespectToDisk = swapBytes(m_nOffsetOfCentralDirectoryWithRespectToDisk);
+		}
 	} ZIP64ENDOFCENTRALDIRHEADER;
 
 	typedef struct {
@@ -137,6 +230,12 @@ namespace NMR {
 		nfUint32 m_nNumberOfDiskWithStartOfZIP64EOCentralDir;
 		nfUint64 m_nRelativeOffset;
 		nfUint32 m_nTotalNumberOfDisk;
+		void swapByteOrder() {
+			m_nSignature = swapBytes(m_nSignature);
+			m_nNumberOfDiskWithStartOfZIP64EOCentralDir = swapBytes(m_nNumberOfDiskWithStartOfZIP64EOCentralDir);
+			m_nRelativeOffset = swapBytes(m_nRelativeOffset);
+			m_nTotalNumberOfDisk = swapBytes(m_nTotalNumberOfDisk);
+		}
 	} ZIP64ENDOFCENTRALDIRLOCATOR;
 
 #pragma pack()

--- a/Include/Common/Platform/NMR_PortableZIPWriterTypes.h
+++ b/Include/Common/Platform/NMR_PortableZIPWriterTypes.h
@@ -34,6 +34,7 @@ NMR_PortableZIPWriterTypes.h defines a portable and fast writer of ZIP files
 #define __NMR_PORTABLEZIPWRITERTYPES
 
 #include "Common/NMR_Types.h"
+#include "Common/NMR_Architecture_Utils.h"
 
 #define ZIPFILEHEADERSIGNATURE 0x04034b50
 #define ZIPFILECENTRALHEADERSIGNATURE 0x02014b50
@@ -58,36 +59,7 @@ NMR_PortableZIPWriterTypes.h defines a portable and fast writer of ZIP files
 
 namespace NMR {
 
-	// helper functions for big-endian architecture
-
-	template<int N>
-	void swapBytesArray(unsigned char(&bytes)[N]) {
-		// Optimize this with a platform-specific API as desired.
-		for (unsigned char *p = bytes, *end = bytes + N - 1; p < end; ++p, --end) {
-			unsigned char tmp = *p;
-			*p = *end;
-			*end = tmp;
-		}
-	}
-	template<typename T>
-	T swapBytes(T value) {
-		swapBytesArray(*reinterpret_cast<unsigned char(*)[sizeof(value)]>(&value));
-		return value;
-	}
-
-	inline bool isBigEndian(void)
-	{
-		union {
-			uint32_t i;
-			char c[4];
-		} bint = { 0x01020304 };
-
-		return bint.c[0] == 1;
-	}
-
 #pragma pack (1)
-	
-
 	typedef struct {
 		nfUint32 m_nSignature;
 		nfUint16 m_nVersion;

--- a/Source/Common/MeshExport/NMR_MeshExporter_STL.cpp
+++ b/Source/Common/MeshExport/NMR_MeshExporter_STL.cpp
@@ -103,15 +103,18 @@ namespace NMR {
 		pStream->writeBuffer(&nFacetCount, sizeof (nFacetCount));
 
 		std::list<MESHFORMAT_STL_FACET>::iterator iter;
-		for (iter = facetdata.begin(); iter != facetdata.end(); iter++) {
-			if (isBigEndian()) {
-				MESHFORMAT_STL_FACET tmpFacet = *iter;
+		if (isBigEndian()) {
+			MESHFORMAT_STL_FACET tmpFacet;
+			for (iter = facetdata.begin(); iter != facetdata.end(); iter++) {
+				tmpFacet = *iter;
 				tmpFacet.swapByteOrder();
 				pStream->writeBuffer(&tmpFacet, sizeof(MESHFORMAT_STL_FACET));
-			} else {
+			}
+		}
+		else {
+			for (iter = facetdata.begin(); iter != facetdata.end(); iter++) {
 				pStream->writeBuffer(&(*iter), sizeof(MESHFORMAT_STL_FACET));
 			}
-			
 		}
 	}
 

--- a/Source/Common/MeshExport/NMR_MeshExporter_STL.cpp
+++ b/Source/Common/MeshExport/NMR_MeshExporter_STL.cpp
@@ -74,13 +74,13 @@ namespace NMR {
 			for (j = 0; j < 3; j++) {
 				node = pMesh->getNode (face->m_nodeindices[j]);
 				if (pmMatrix)
-					facet.m_vertieces[j] = fnMATRIX3_apply(*pmMatrix, node->m_position);
+					facet.m_vertices[j] = fnMATRIX3_apply(*pmMatrix, node->m_position);
 				else
-					facet.m_vertieces[j] = node->m_position;
+					facet.m_vertices[j] = node->m_position;
 			}	
 
 			// Calculate Triangle Normals
-			facet.m_normal = fnVEC3_calcTriangleNormal(facet.m_vertieces[0], facet.m_vertieces[1], facet.m_vertieces[2]);
+			facet.m_normal = fnVEC3_calcTriangleNormal(facet.m_vertices[0], facet.m_vertices[1], facet.m_vertices[2]);
 			facet.m_attribute = 0;
 
 			facetdata.push_back(facet);
@@ -98,11 +98,20 @@ namespace NMR {
 
 		// Write Header
 		pStream->writeBuffer(&stlheader[0], 80);
+		if (isBigEndian())
+			nFacetCount = swapBytes(nFacetCount);
 		pStream->writeBuffer(&nFacetCount, sizeof (nFacetCount));
 
 		std::list<MESHFORMAT_STL_FACET>::iterator iter;
 		for (iter = facetdata.begin(); iter != facetdata.end(); iter++) {
-			pStream->writeBuffer(&(*iter), sizeof (MESHFORMAT_STL_FACET));
+			if (isBigEndian()) {
+				MESHFORMAT_STL_FACET tmpFacet = *iter;
+				tmpFacet.swapByteOrder();
+				pStream->writeBuffer(&tmpFacet, sizeof(MESHFORMAT_STL_FACET));
+			} else {
+				pStream->writeBuffer(&(*iter), sizeof(MESHFORMAT_STL_FACET));
+			}
+			
 		}
 	}
 

--- a/Source/Common/MeshImport/NMR_MeshImporter_STL.cpp
+++ b/Source/Common/MeshImport/NMR_MeshImporter_STL.cpp
@@ -128,6 +128,9 @@ namespace NMR {
 
 		pStream->readBuffer(&aSTLHeader[0], 80, true);
 		pStream->readBuffer((nfByte*)&nFaceCount, sizeof(nFaceCount), true);
+		if (isBigEndian()) {
+			nFaceCount = swapBytes(nFaceCount);
+		}
 
 		if (nFaceCount > NMR_MESH_MAXFACECOUNT)
 			throw CNMRException(NMR_ERROR_INVALIDFACECOUNT);
@@ -141,7 +144,7 @@ namespace NMR {
 			}
 		}
 
-		nfUint32 nIdx, j, k, nNodeIdx;
+		nfUint32 nNodeIdx;
 		MESHNODE * pNodes[3];
 		MESHFORMAT_STL_FACET Facet;
 		CVectorTree VectorTree;
@@ -149,20 +152,23 @@ namespace NMR {
 
 		VectorTree.setUnits(m_fUnits);
 
-		for (nIdx = 0; nIdx < nFaceCount; nIdx++) {
+		for (nfUint32 nIdx = 0; nIdx < nFaceCount; nIdx++) {
 			pStream->readBuffer((nfByte*)&Facet, sizeof(Facet), true);
+			if (isBigEndian()) {
+				Facet.swapByteOrder();
+			}
 
 			// Check, if Coordinates are in Valid Space
 			bIsValid = true;
-			for (j = 0; j < 3; j++)
-				for (k = 0; k < 3; k++)
-					bIsValid &= (fabs(Facet.m_vertieces[j].m_fields[k]) < NMR_MESH_MAXCOORDINATE);
+			for (nfUint32 j = 0; j < 3; j++)
+				for (nfUint32 k = 0; k < 3; k++)
+					bIsValid &= (fabs(Facet.m_vertices[j].m_fields[k]) < NMR_MESH_MAXCOORDINATE);
 
 			// Identify Nodes via Tree
 			if (bIsValid) {
 
-				for (j = 0; j < 3; j++) {
-					NVEC3 vPosition = Facet.m_vertieces[j];
+				for (nfUint32 j = 0; j < 3; j++) {
+					NVEC3 vPosition = Facet.m_vertices[j];
 					if (pmMatrix)
 						vPosition = fnMATRIX3_apply(*pmMatrix, vPosition);
 

--- a/Source/Common/Platform/NMR_PortableZIPWriter.cpp
+++ b/Source/Common/Platform/NMR_PortableZIPWriter.cpp
@@ -120,11 +120,21 @@ namespace NMR {
 
 		// Write data to ZIP stream
 		nfUint64 nFilePosition = m_pExportStream->getPosition();
+		
+		// prepare byte-buffer for big-endian machines
+		if (isBigEndian()) {
+			LocalHeader.swapByteOrder();
+		}
 		m_pExportStream->writeBuffer(&LocalHeader, sizeof(LocalHeader));
 		m_pExportStream->writeBuffer(sUTF8Name.c_str(), nNameLength);
 		nfUint64 nExtInfoPosition = m_pExportStream->getPosition();
-		if (m_bWriteZIP64)
+		if (m_bWriteZIP64) {
+			// prepare byte-buffer for big-endian machines
+			if (isBigEndian()) {
+				zip64ExtraInformation.swapByteOrder();
+			}
 			m_pExportStream->writeBuffer(&zip64ExtraInformation, sizeof(zip64ExtraInformation));
+		}
 
 		nfUint64 nDataPosition = m_pExportStream->getPosition();
 
@@ -172,11 +182,21 @@ namespace NMR {
 			
 			// Write File Descriptor to file
 			m_pExportStream->seekPosition(m_pCurrentEntry->getFilePosition() + ZIPFILEDESCRIPTOROFFSET, true);
+			
+			// prepare byte-buffer for big-endian machines
+			if (isBigEndian()) {
+				FileDescriptor.swapByteOrder();
+			}
 			m_pExportStream->writeBuffer(&FileDescriptor, sizeof(FileDescriptor));
 
 			if (m_bWriteZIP64) {
 				// Write Extra Information to file
 				m_pExportStream->seekPosition(m_pCurrentEntry->getExtInfoPosition(), true);
+
+				// prepare byte-buffer for big-endian machines
+				if (isBigEndian()) {
+					zip64ExtraInformation.swapByteOrder();
+				}
 				m_pExportStream->writeBuffer(&zip64ExtraInformation, sizeof(zip64ExtraInformation));
 			}
 
@@ -280,6 +300,10 @@ namespace NMR {
 				DirectoryHeader.m_nUnCompressedSize = (nfUint32)pEntry->getUncompressedSize();
 			}
 
+			// prepare byte-buffer for big-endian machines
+			if (isBigEndian()) {
+				DirectoryHeader.swapByteOrder();
+			}
 			m_pExportStream->writeBuffer(&DirectoryHeader, (nfUint64) sizeof(DirectoryHeader));
 			m_pExportStream->writeBuffer(sUTF8Name.c_str(), nNameLength);
 			
@@ -290,6 +314,11 @@ namespace NMR {
 				zip64ExtraInformation.m_nCompressedSize = pEntry->getCompressedSize();
 				zip64ExtraInformation.m_nUncompressedSize = pEntry->getUncompressedSize();
 
+				// prepare byte-buffer for big-endian machines
+				if (isBigEndian()) {
+					zip64ExtraInformation.swapByteOrder();
+					nRelativeOffsetOfLocalHeader = swapBytes(nRelativeOffsetOfLocalHeader);
+				}
 				m_pExportStream->writeBuffer(&zip64ExtraInformation, sizeof(zip64ExtraInformation));
 				m_pExportStream->writeBuffer(&nRelativeOffsetOfLocalHeader, sizeof(nRelativeOffsetOfLocalHeader));
 			}
@@ -331,8 +360,17 @@ namespace NMR {
 
 		if (m_bWriteZIP64) {
 			EndHeader.m_nOffsetOfCentralDirectory = 0xFFFFFFFF;
+			// prepare byte-buffer for big-endian machines
+			if (isBigEndian()) {
+				EndHeader64.swapByteOrder();
+				EndLocator64.swapByteOrder();
+			}
 			m_pExportStream->writeBuffer(&EndHeader64, sizeof(EndHeader64));
 			m_pExportStream->writeBuffer(&EndLocator64, sizeof(EndLocator64));
+		}
+		// prepare byte-buffer for big-endian machines
+		if (isBigEndian()) {
+			EndHeader.swapByteOrder();
 		}
 		m_pExportStream->writeBuffer(&EndHeader, (nfUint64) sizeof(EndHeader));
 

--- a/Tests/CPP_Bindings/Source/Reader.cpp
+++ b/Tests/CPP_Bindings/Source/Reader.cpp
@@ -71,6 +71,18 @@ namespace Lib3MF
 		CheckReaderWarnings(Reader::readerSTL, 0);
 	}
 
+	TEST_F(Reader, STLReadWriteRead)
+	{
+		Reader::readerSTL->ReadFromFile(sTestFilesPath + "/Reader/" + "Pyramid.stl");
+		CheckReaderWarnings(Reader::readerSTL, 0);
+		auto stlWriter = model->QueryWriter("stl");
+		std::vector<Lib3MF_uint8> stlBuffer;
+		stlWriter->WriteToBuffer(stlBuffer);
+		auto tmpModel = wrapper->CreateModel();
+		auto tmpReader = tmpModel->QueryReader("stl");
+		tmpReader->ReadFromBuffer(stlBuffer);
+	}
+
 	TEST_F(Reader, 3MFReadFromBuffer)
 	{
 		auto buffer = ReadFileIntoBuffer(sTestFilesPath + "/Reader/" + "Pyramid.3mf");


### PR DESCRIPTION
Fixes https://github.com/3MFConsortium/lib3mf/issues/160

This PR:
- fixes writing of .3mf-files on big endian-machines
- fixes reading and writing of .stl-files on big endian-machines
- modifies the travis-CI configuration to also build and test lib3mf on a big-endian linux machine. This build takes ~40 minutes though. It might need to be removed again to not hinder the development of lib3mf.

@knielsen: does this work for you/OpenSCAD?
