### PR TITLE
Precision of float output can now be changed

### DIFF
--- a/AutomaticComponentToolkit/lib3mf.xml
+++ b/AutomaticComponentToolkit/lib3mf.xml
@@ -289,6 +289,12 @@
 			<param name="ProgressCallback" type="functiontype" class="ProgressCallback" pass="in" description="pointer to the callback function."/>
 			<param name="UserData" type="pointer" pass="in" description="pointer to arbitrary user data that is passed without modification to the callback."/>
 		</method>
+		<method name="GetDecimalPrecision" description = "Returns the number of digits after the decimal point to be written in each vertex coordinate-value.">
+			<param name="DecimalPrecision" type="uint32" pass="return" description="The number of digits to be written in each vertex coordinate-value after the decimal point." />
+		</method>
+		<method name="SetDecimalPrecision" description = "Sets the number of digits after the decimal point to be written in each vertex coordinate-value.">
+			<param name="DecimalPrecision" type="uint32" pass="in" description="The number of digits to be written in each vertex coordinate-value after the decimal point." />
+		</method>
 	</class>
 
 	<class name="Reader">

--- a/Include/API/lib3mf_writer.hpp
+++ b/Include/API/lib3mf_writer.hpp
@@ -87,6 +87,10 @@ public:
 	void WriteToCallback(const Lib3MFWriteCallback pTheWriteCallback, const Lib3MFSeekCallback pTheSeekCallback, const Lib3MF_pvoid pUserData);
 
 	void SetProgressCallback(const Lib3MFProgressCallback pProgressCallback, const Lib3MF_pvoid pUserData);
+
+	Lib3MF_uint32 GetDecimalPrecision() override;
+
+	void SetDecimalPrecision(const Lib3MF_uint32 nDecimalPrecision) override;
 };
 
 }

--- a/Include/Model/Writer/NMR_ModelWriter.h
+++ b/Include/Model/Writer/NMR_ModelWriter.h
@@ -43,7 +43,7 @@ namespace NMR {
 
 	class CModelWriter {
 	private:
-			
+		nfUint32 m_nDecimalPrecision;
 	protected:
 		PModel m_pModel;
 		PProgressMonitor m_pProgressMonitor;
@@ -56,6 +56,9 @@ namespace NMR {
  		void removeCustomContentType(_In_ std::wstring sExtension);
 
 		void SetProgressCallback(Lib3MFProgressCallback callback, void* userData);
+
+		void SetDecimalPrecision(nfUint32);
+		nfUint32 GetDecimalPrecision();
 	};
 
 	typedef std::shared_ptr <CModelWriter> PModelWriter;

--- a/Include/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.h
+++ b/Include/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.h
@@ -75,10 +75,10 @@ namespace NMR {
 		nfUint32 m_nBeamBufferPos;
 		nfUint32 m_nBeamRefBufferPos;
 	private:
-		static const int m_snPosAfterDecPoint = 6;
-		static const int m_snPutDoubleFactor;
-		static __NMR_INLINE void putFloat(_In_ const nfFloat fValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos);
-		static __NMR_INLINE void putDouble(_In_ const nfDouble dValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos);
+		const int m_nPosAfterDecPoint;
+		const int m_nPutDoubleFactor;
+		__NMR_INLINE void putFloat(_In_ const nfFloat fValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos);
+		__NMR_INLINE void putDouble(_In_ const nfDouble dValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos);
 
 	protected:
 		__NMR_INLINE void putVertexString(_In_ const nfChar * pszString);
@@ -103,7 +103,7 @@ namespace NMR {
 	public:
 		CModelWriterNode100_Mesh() = delete;
 		CModelWriterNode100_Mesh(_In_ CModelMeshObject * pModelMeshObject, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor,
-			_In_ PMeshInformation_PropertyIndexMapping pPropertyIndexMapping, _In_ nfBool bWriteMaterialExtension, _In_ nfBool m_bWriteBeamLatticeExtension);
+			_In_ PMeshInformation_PropertyIndexMapping pPropertyIndexMapping, _In_ int nPosAfterDecPoint, _In_ nfBool bWriteMaterialExtension, _In_ nfBool m_bWriteBeamLatticeExtension);
 		virtual void writeToXML();
 	};
 

--- a/Include/Model/Writer/v100/NMR_ModelWriterNode100_Model.h
+++ b/Include/Model/Writer/v100/NMR_ModelWriterNode100_Model.h
@@ -47,6 +47,7 @@ namespace NMR {
 
 	class CModelWriterNode100_Model : public CModelWriterNode {
 	protected:
+		nfUint32 m_nDecimalPrecision;
 		ModelResourceID m_ResourceCounter;
 		
 		PMeshInformation_PropertyIndexMapping m_pPropertyIndexMapping;
@@ -90,8 +91,8 @@ namespace NMR {
 
 	public:
 		CModelWriterNode100_Model() = delete;
-		CModelWriterNode100_Model(_In_ CModel * pModel, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor);
-		CModelWriterNode100_Model(_In_ CModel * pModel, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor, nfBool bWritesRootModel);
+		CModelWriterNode100_Model(_In_ CModel * pModel, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor, _In_ nfUint32 nDecimalPrecision);
+		CModelWriterNode100_Model(_In_ CModel * pModel, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor, _In_ nfUint32 nDecimalPrecision, _In_ nfBool bWritesRootModel);
 		
 		virtual void writeToXML();
 	};

--- a/Source/API/lib3mf_writer.cpp
+++ b/Source/API/lib3mf_writer.cpp
@@ -163,3 +163,13 @@ void CWriter::SetProgressCallback(const Lib3MFProgressCallback callback, const L
 	m_pWriter->SetProgressCallback(lambdaCallback, reinterpret_cast<void*>(pUserData));
 }
 
+Lib3MF_uint32 CWriter::GetDecimalPrecision()
+{
+	return m_pWriter->GetDecimalPrecision();
+}
+
+void CWriter::SetDecimalPrecision(const Lib3MF_uint32 nDecimalPrecision)
+{
+	m_pWriter->SetDecimalPrecision(nDecimalPrecision);
+}
+

--- a/Source/Model/Writer/NMR_ModelWriter.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter.cpp
@@ -42,7 +42,11 @@ A model writer exports the in memory represenation into a model file.
 
 namespace NMR {
 
-	CModelWriter::CModelWriter(_In_ PModel pModel)
+	const int MIN_DECIMAL_PRECISION = 1;
+	const int MAX_DECIMAL_PRECISION = 16;
+
+	CModelWriter::CModelWriter(_In_ PModel pModel):
+		m_nDecimalPrecision(6)
 	{
 		if (!pModel.get())
 			throw CNMRException(NMR_ERROR_INVALIDPARAM);
@@ -55,4 +59,17 @@ namespace NMR {
 	{
 		m_pProgressMonitor->SetProgressCallback(callback, userData);
 	}
+
+	void CModelWriter::SetDecimalPrecision(nfUint32 nDecimalPrecision)
+	{
+		if ((nDecimalPrecision < MIN_DECIMAL_PRECISION) || (nDecimalPrecision > MAX_DECIMAL_PRECISION))
+			throw CNMRException(NMR_ERROR_INVALIDPARAM);
+		m_nDecimalPrecision = nDecimalPrecision;
+	}
+
+	nfUint32 CModelWriter::GetDecimalPrecision()
+	{
+		return m_nDecimalPrecision;
+	}
+
 }

--- a/Source/Model/Writer/NMR_ModelWriter_3MF.cpp
+++ b/Source/Model/Writer/NMR_ModelWriter_3MF.cpp
@@ -85,7 +85,7 @@ namespace NMR {
 			throw CNMRException(NMR_ERROR_INVALIDPARAM);
 
 		pXMLWriter->WriteStartDocument();
-		CModelWriterNode100_Model ModelNode(m_pModel.get(), pXMLWriter, m_pProgressMonitor, false);
+		CModelWriterNode100_Model ModelNode(m_pModel.get(), pXMLWriter, m_pProgressMonitor, GetDecimalPrecision(), false);
 		ModelNode.writeToXML();
 
 		pXMLWriter->WriteEndDocument();
@@ -100,7 +100,7 @@ namespace NMR {
 
 		pXMLWriter->WriteStartDocument();
 
-		CModelWriterNode100_Model ModelNode(pModel, pXMLWriter, m_pProgressMonitor);
+		CModelWriterNode100_Model ModelNode(pModel, pXMLWriter, m_pProgressMonitor, GetDecimalPrecision());
 		ModelNode.writeToXML();
 
 		pXMLWriter->WriteEndDocument();

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
@@ -49,11 +49,10 @@ This is the class for exporting the 3mf mesh node.
 #define MAX(a,b) (((a)>(b))?(a):(b))
 
 namespace NMR {
-	const int CModelWriterNode100_Mesh::m_snPutDoubleFactor = (int)(pow(10, CModelWriterNode100_Mesh::m_snPosAfterDecPoint));
 
 	CModelWriterNode100_Mesh::CModelWriterNode100_Mesh(_In_ CModelMeshObject * pModelMeshObject, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor,
-		_In_ PMeshInformation_PropertyIndexMapping pPropertyIndexMapping, _In_ nfBool bWriteMaterialExtension, _In_ nfBool bWriteBeamLatticeExtension)
-		:CModelWriterNode(pModelMeshObject->getModel(), pXMLWriter, pProgressMonitor)
+		_In_ PMeshInformation_PropertyIndexMapping pPropertyIndexMapping, _In_ int nPosAfterDecPoint, _In_ nfBool bWriteMaterialExtension, _In_ nfBool bWriteBeamLatticeExtension)
+		:CModelWriterNode(pModelMeshObject->getModel(), pXMLWriter, pProgressMonitor), m_nPosAfterDecPoint(nPosAfterDecPoint), m_nPutDoubleFactor((int)(pow(10, CModelWriterNode100_Mesh::m_nPosAfterDecPoint)))
 	{
 		__NMRASSERT(pModelMeshObject != nullptr);
 		if (!pPropertyIndexMapping.get())
@@ -315,7 +314,7 @@ namespace NMR {
 
 	void CModelWriterNode100_Mesh::putFloat(_In_ const nfFloat fValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos) {
 		// Format float with "%.$ACCf" syntax where $ACC = m_snPosAfterDecPoint
-		nfInt64 nAbsValue = (nfInt64)(fValue * m_snPutDoubleFactor);
+		nfInt64 nAbsValue = (nfInt64)(fValue * m_nPutDoubleFactor);
 		nAbsValue = MAX(nAbsValue, -nAbsValue);
 		nfBool bIsNegative = fValue < 0;
 
@@ -327,11 +326,11 @@ namespace NMR {
 		}
 		else {
 			// Write the string in reverse order
-			while (nAbsValue || nCount < m_snPosAfterDecPoint) {
+			while (nAbsValue || nCount < m_nPosAfterDecPoint) {
 				line[nBufferPos++] = '0' + (nAbsValue % 10);
 				nAbsValue /= 10;
 				nCount++;
-				if (nCount == m_snPosAfterDecPoint) {
+				if (nCount == m_nPosAfterDecPoint) {
 					line[nBufferPos++] = '.';
 					if (!nAbsValue) {
 						line[nBufferPos++] = '0';
@@ -358,7 +357,7 @@ namespace NMR {
 
 	void CModelWriterNode100_Mesh::putDouble(_In_ const nfDouble dValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos) {
 		// Format float with "%.$ACCf" syntax where $ACC = m_snPosAfterDecPoint
-		nfInt64 nAbsValue = (nfInt64)(dValue * m_snPutDoubleFactor);
+		nfInt64 nAbsValue = (nfInt64)(dValue * m_nPutDoubleFactor);
 		nAbsValue = MAX(nAbsValue, -nAbsValue);
 		nfBool bIsNegative = dValue < 0;
 
@@ -370,11 +369,11 @@ namespace NMR {
 		}
 		else {
 			// Write the string in reverse order
-			while (nAbsValue || nCount < m_snPosAfterDecPoint) {
+			while (nAbsValue || nCount < m_nPosAfterDecPoint) {
 				line[nBufferPos++] = '0' + (nAbsValue % 10);
 				nAbsValue /= 10;
 				nCount++;
-				if (nCount == m_snPosAfterDecPoint) {
+				if (nCount == m_nPosAfterDecPoint) {
 					line[nBufferPos++] = '.';
 					if (!nAbsValue) {
 						line[nBufferPos++] = '0';
@@ -589,8 +588,8 @@ namespace NMR {
 		putBeamString(sV2.c_str());
 		putBeamUInt32(pBeam->m_nodeindices[1]);
 
-		nfBool bWriteR2 = stringRepresentationsDiffer(pBeam->m_radius[0], pBeam->m_radius[1], m_snPutDoubleFactor);
-		nfBool bWriteR1 = bWriteR2 || stringRepresentationsDiffer(pBeam->m_radius[0], dRadius, m_snPutDoubleFactor);
+		nfBool bWriteR2 = stringRepresentationsDiffer(pBeam->m_radius[0], pBeam->m_radius[1], m_nPutDoubleFactor);
+		nfBool bWriteR1 = bWriteR2 || stringRepresentationsDiffer(pBeam->m_radius[0], dRadius, m_nPutDoubleFactor);
 		if (bWriteR1) {
 			const std::string sR1 = "\" " + std::string(XML_3MF_ATTRIBUTE_BEAMLATTICE_R1) + "=\"";
 			putBeamString(sR1.c_str());

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Model.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Model.cpp
@@ -57,8 +57,8 @@ This is the class for exporting the 3mf model stream root node.
 
 namespace NMR {
 
-	CModelWriterNode100_Model::CModelWriterNode100_Model(_In_ CModel * pModel, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor)
-		:CModelWriterNode(pModel, pXMLWriter, pProgressMonitor)
+	CModelWriterNode100_Model::CModelWriterNode100_Model(_In_ CModel * pModel, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor, _In_ nfUint32 nDecimalPrecision)
+		:CModelWriterNode(pModel, pXMLWriter, pProgressMonitor), m_nDecimalPrecision(nDecimalPrecision)
 	{
 		m_ResourceCounter = pModel->generateResourceID();
 
@@ -80,7 +80,7 @@ namespace NMR {
 
 
 	CModelWriterNode100_Model::CModelWriterNode100_Model(_In_ CModel * pModel, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor,
-		nfBool bWritesRootModel) : CModelWriterNode(pModel, pXMLWriter, pProgressMonitor)
+		_In_ nfUint32 nDecimalPrecision, nfBool bWritesRootModel) : CModelWriterNode(pModel, pXMLWriter, pProgressMonitor), m_nDecimalPrecision(nDecimalPrecision)
 	{
 		if (bWritesRootModel) {
 			throw CNMRException(NMR_ERROR_INVALIDPARAM);
@@ -485,7 +485,7 @@ namespace NMR {
 				}
 
 				CModelWriterNode100_Mesh ModelWriter_Mesh(pMeshObject, m_pXMLWriter, m_pProgressMonitor,
-					m_pPropertyIndexMapping, m_bWriteMaterialExtension, m_bWriteBeamLatticeExtension);
+					m_pPropertyIndexMapping, m_nDecimalPrecision, m_bWriteMaterialExtension, m_bWriteBeamLatticeExtension);
 
 				ModelWriter_Mesh.writeToXML();
 			}

--- a/Tests/CPP_Bindings/Source/Writer.cpp
+++ b/Tests/CPP_Bindings/Source/Writer.cpp
@@ -103,6 +103,26 @@ namespace Lib3MF
 		ASSERT_TRUE(std::equal(buffer.begin(), buffer.end(), bufferFromFile.begin()));
 	}
 
+	TEST_F(Writer, 3MFPrecision)
+	{
+		std::vector<sPosition> vctVertices;
+		std::vector<sTriangle> vctTriangles;
+		fnCreateBox(vctVertices, vctTriangles);
+		auto mesh = model->AddMeshObject();
+		mesh->SetGeometry(vctVertices, vctTriangles);
+
+		// This test is atleast functional
+		std::vector<Lib3MF_uint8> buffer;
+		Writer::writer3MF->WriteToBuffer(buffer);
+
+		Lib3MF_uint32 nPrecission = writer3MF->GetDecimalPrecision();
+		writer3MF->SetDecimalPrecision(nPrecission+2);
+		std::vector<Lib3MF_uint8> bufferLargr;
+		Writer::writer3MF->WriteToBuffer(bufferLargr);
+
+		ASSERT_TRUE(buffer.size() < bufferLargr.size());
+	}
+
 	TEST_F(Writer, STLCompare)
 	{
 		// This test is atleast functional


### PR DESCRIPTION
Fixes https://github.com/3MFConsortium/lib3mf/issues/28.
Does not cover  #25 .

Writer-class gets new methods `GetDecimalPrecision` and `SetDecimalPrecision` which sets the number of decimal digits (after the decimal dot) that are serialized into a file.
Currently, only the 3mf-writer makes use of this. ASCII-STL-writer should respect this, too, at some point.

Verified that write performance is not degraded by this change.