### PR TITLE
Fix GetLastError

### DIFF
--- a/Source/API/lib3mf_base.cpp
+++ b/Source/API/lib3mf_base.cpp
@@ -44,7 +44,6 @@ bool CBase::GetLastErrorMessage(std::string & sErrorMessage)
 {
 	if (m_pErrors && !m_pErrors->empty()) {
 		sErrorMessage = m_pErrors->back();
-		m_pErrors->pop_back();
 		return true;
 	} else {
 		sErrorMessage = "";
@@ -62,6 +61,7 @@ void CBase::RegisterErrorMessage(const std::string & sErrorMessage)
 	if (!m_pErrors) {
 		m_pErrors.reset(new std::list<std::string>());
 	}
+	m_pErrors->clear();
 	m_pErrors->push_back(sErrorMessage);
 }
 


### PR DESCRIPTION
Resolves https://github.com/3MFConsortium/lib3mf/issues/170

Internal / generic exceptions (API error code 5) now correctly propagate to the client code.

Other exceptions will still only show their error code.