### PR TITLE
develop_v1_legacy: link against libzip/zlib when USE_INCLUDED_{LIBZIP,ZLIB}=OFF is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,17 @@ else()
 	target_compile_options(${PROJECT_NAME}_s PUBLIC "$<$<CONFIG:RELEASE>:/O2;/sdl;/WX;/Oi;/Gy;/FC;/wd4996>")
 endif()
 
+if (NOT USE_INCLUDED_LIBZIP)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(LIBZIP REQUIRED libzip)
+	target_link_libraries(${PROJECT_NAME}_s ${LIBZIP_LIBRARIES})
+endif()
+if (NOT USE_INCLUDED_ZLIB)
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(ZLIB REQUIRED zlib)
+	target_link_libraries(${PROJECT_NAME}_s ${ZLIB_LIBRARIES})
+endif()
+
 
 #########################################################
 # Shared library

--- a/lib3MF.pc.in
+++ b/lib3MF.pc.in
@@ -8,5 +8,6 @@ Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
 Requires:
-Libs: -L${libdir} -l3MF -lzip -lz
+Libs: -L${libdir} -l3MF
+Libs.private: @LIBZIP_LDFLAGS@ @ZLIB_LDFLAGS@
 Cflags: -I${includedir}


### PR DESCRIPTION
`lib3MF.so` is not explicitly linked against `libzip` or `zlib` even when `USE_INCLUDED_LIBZIP=OFF` or `USE_INCLUDED_ZLIB=OFF` are used. These dependencies are only specified in the "Libs" section of the [pkg-config file](https://github.com/3MFConsortium/lib3mf/blob/master/lib3MF.pc.in). People trying to link the library directly without relying on the pkg-config file will face errors like
```
/usr/bin/ld: lib3MF.so.1.8.1.0: undefined reference to `deflateInit2_'
```
This can be immediately observed when trying to compile lib3mf with
```
cmake -DUSE_INCLUDED_LIBZIP=OFF -DUSE_INCLUDED_ZLIB=OFF
      -DLIB3MF_TESTS=ON
```
The solution is to link lib3mf against all the necessary libraries so that they can be pulled in automatically during linking. This allows to move them from "Libs" to "Libs.private" in the pkg-config file since they do not need to be specified explicitly any more. With this change, compilation with the test suite as shown above works.

As another small improvement, use `@LIBZIP_LDFLAGS@` and `@ZLIB_LDFLAGS@` instead of statically specifying the required libraries. This guarantees that only the actually necessary libraries (depending on the value of `USE_INCLUDED_...`) are added as dependencies.