### PR TITLE
 develop_v1_legacy: add configuration option to use system Google Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(NMR_COM_NATIVE "Implement a COM interface" OFF)
 
 option(USE_INCLUDED_ZLIB "Use included zlib" ON)
 option(USE_INCLUDED_LIBZIP "Use included libzip" ON)
+option(USE_INCLUDED_GTEST "Used included gtest" ON)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # using GCC

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -1,7 +1,10 @@
-ADD_SUBDIRECTORY (googletest EXCLUDE_FROM_ALL)
 enable_testing()
-	
-SET(gtest_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest")
+
+if (USE_INCLUDED_GTEST)
+	ADD_SUBDIRECTORY (googletest EXCLUDE_FROM_ALL)
+	SET(gtest_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest")
+endif()
+
 add_definitions( -DTESTFILESPATH="${CMAKE_CURRENT_SOURCE_DIR}/../TestFiles")
 add_definitions( -DLTESTFILESPATH=L"${CMAKE_CURRENT_SOURCE_DIR}/../TestFiles")
 add_definitions( -DLOUTFILESPATH=L"${CMAKE_BINARY_DIR}/")


### PR DESCRIPTION
This is a backport of PR #186 for the legacy version.