### PR TITLE
Fix memory leak in libzip when reading files

### DIFF
--- a/Source/Common/OPC/NMR_OpcPackageReader.cpp
+++ b/Source/Common/OPC/NMR_OpcPackageReader.cpp
@@ -54,7 +54,7 @@ namespace NMR {
 			case ZIP_SOURCE_SUPPORTS:
 				zip_int64_t bitmap;
 				bitmap = zip_source_make_command_bitmap(ZIP_SOURCE_OPEN, ZIP_SOURCE_READ, ZIP_SOURCE_CLOSE,
-					ZIP_SOURCE_STAT, ZIP_SOURCE_ERROR, ZIP_SOURCE_SEEK, ZIP_SOURCE_TELL, ZIP_SOURCE_SUPPORTS, -1);
+					ZIP_SOURCE_STAT, ZIP_SOURCE_ERROR, ZIP_SOURCE_FREE, ZIP_SOURCE_SEEK, ZIP_SOURCE_TELL, ZIP_SOURCE_SUPPORTS, -1);
 				return bitmap;
 
 			case ZIP_SOURCE_SEEK:
@@ -93,6 +93,9 @@ namespace NMR {
 				zipStat->size = pImportStream->retrieveSize();
 				zipStat->valid |= ZIP_STAT_SIZE;
 				return sizeof(zip_stat_t);
+
+			case ZIP_SOURCE_FREE:
+				return 0;
 
 			default:
 				throw CNMRException(NMR_ERROR_ZIPCALLBACK);


### PR DESCRIPTION
This change is based on https://github.com/nih-at/libzip/issues/44

This PR fixes subissue 1 of https://github.com/3MFConsortium/lib3mf/issues/180 .