### PR TITLE
Add triangles during STL read

### DIFF
--- a/Source/Common/MeshImport/NMR_MeshImporter_STL.cpp
+++ b/Source/Common/MeshImport/NMR_MeshImporter_STL.cpp
@@ -181,6 +181,7 @@ namespace NMR {
 						VectorTree.addVector3(pNodes[j]->m_position, (nfUint32)pNodes[j]->m_index);
 					}
 				}
+				pMesh->addFace(pNodes[0], pNodes[1], pNodes[2]);
 
 				// check, if Nodes are separate
 				bIsValid = (pNodes[0] != pNodes[1]) && (pNodes[0] != pNodes[2]) && (pNodes[1] != pNodes[2]);

--- a/Tests/CPP_Bindings/Source/Reader.cpp
+++ b/Tests/CPP_Bindings/Source/Reader.cpp
@@ -69,6 +69,13 @@ namespace Lib3MF
 	{
 		Reader::readerSTL->ReadFromFile(sTestFilesPath + "/Reader/" + "Pyramid.stl");
 		CheckReaderWarnings(Reader::readerSTL, 0);
+		auto meshObjects = model->GetMeshObjects();
+		ASSERT_TRUE(meshObjects->Count() > 0);
+		while (meshObjects->MoveNext()) {
+			auto meshObject = meshObjects->GetCurrentMeshObject();
+			ASSERT_TRUE(meshObject->GetVertexCount() > 0);
+			ASSERT_TRUE(meshObject->GetTriangleCount() > 0);
+		}
 	}
 
 	TEST_F(Reader, STLReadWriteRead)


### PR DESCRIPTION
I don't know why, but it seems you commented out some code which is necessary to correctly read STLs. It simply does not add any faces to the mesh during the read process.

The addition of this single line makes the STL reader work again.