### PR TITLE
Avoids exception for duplicated meta-data on model

### DIFF
--- a/Source/Model/Reader/NMR_ModelReaderNode_Model.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderNode_Model.cpp
@@ -158,23 +158,25 @@ namespace NMR {
 			if (m_pModel->hasMetaData(sKey)) {
 				m_pWarnings->addWarning(MODELREADERWARNING_DUPLICATEMETADATA, NMR_ERROR_DUPLICATEMETADATA, mrwInvalidOptionalValue);
 			}
-			std::string sNameSpace, sName;
-			decomposeKeyIntoNamespaceAndName(sKey, sNameSpace, sName);
-			if (!sNameSpace.empty()) {
-				std::string sNameSpaceURI;
-				if (!pXMLReader->GetNamespaceURI(sNameSpace, sNameSpaceURI)) {
-					m_pWarnings->addException(CNMRException(NMR_ERROR_METADATA_COULDNOTGETNAMESPACE), mrwInvalidOptionalValue);
-					sNameSpaceURI = sNameSpace;
-				}
-				m_pModel->addMetaData(sNameSpaceURI, sName, sValue, sType, bPreserve);
-			}
 			else {
-				// default namespace
-				if (CModelMetaData::isValidNamespaceAndName("", sName)) {
-					m_pModel->addMetaData("", sName, sValue, sType, bPreserve);
+				std::string sNameSpace, sName;
+				decomposeKeyIntoNamespaceAndName(sKey, sNameSpace, sName);
+				if (!sNameSpace.empty()) {
+					std::string sNameSpaceURI;
+					if (!pXMLReader->GetNamespaceURI(sNameSpace, sNameSpaceURI)) {
+						m_pWarnings->addException(CNMRException(NMR_ERROR_METADATA_COULDNOTGETNAMESPACE), mrwInvalidOptionalValue);
+						sNameSpaceURI = sNameSpace;
+					}
+					m_pModel->addMetaData(sNameSpaceURI, sName, sValue, sType, bPreserve);
 				}
-				else
-					m_pWarnings->addException(CNMRException(NMR_ERROR_UNKNOWNMETADATA), mrwInvalidOptionalValue);
+				else {
+					// default namespace
+					if (CModelMetaData::isValidNamespaceAndName("", sName)) {
+						m_pModel->addMetaData("", sName, sValue, sType, bPreserve);
+					}
+					else
+						m_pWarnings->addException(CNMRException(NMR_ERROR_UNKNOWNMETADATA), mrwInvalidOptionalValue);
+				}
 			}
 		}
 		else {

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Model.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Model.cpp
@@ -447,8 +447,6 @@ namespace NMR {
 				}
 			}
 
-			writeMetaDataGroup(pObject->metaDataGroup());
-
 			// Check if object is a mesh Object
 			CModelMeshObject * pMeshObject = dynamic_cast<CModelMeshObject *> (pObject);
 			if (pMeshObject) {
@@ -481,7 +479,11 @@ namespace NMR {
 					writeIntAttribute(XML_3MF_ATTRIBUTE_OBJECT_PID, nObjectLevelPropertyID);
 					writeIntAttribute(XML_3MF_ATTRIBUTE_OBJECT_PINDEX, nObjectLevelPropertyIndex);
 				}
+			}
 
+			writeMetaDataGroup(pObject->metaDataGroup());
+
+			if (pMeshObject) {
 				CModelWriterNode100_Mesh ModelWriter_Mesh(pMeshObject, m_pXMLWriter, m_pProgressMonitor,
 					m_pPropertyIndexMapping, m_nDecimalPrecision, m_bWriteMaterialExtension, m_bWriteBeamLatticeExtension);
 

--- a/Tests/CPP_Bindings/Source/Properties.cpp
+++ b/Tests/CPP_Bindings/Source/Properties.cpp
@@ -166,6 +166,55 @@ namespace Lib3MF
 		CompareColors(baseMaterialGroup->GetDisplayColor(someMaterial), readBaseMaterialGroup->GetDisplayColor(nObjectPropertyID));
 	}
 
+	// Copy-pasted from the previous test ("ObjectLevelPropertiesWriteRead"), but adds metadata to the mesh
+	TEST_F(Properties, ObjectLevelPropertiesWriteRead_WithMetaData)
+	{
+		auto baseMaterialGroup = model->AddBaseMaterialGroup();
+		auto someMaterial = baseMaterialGroup->AddMaterial("SomeMaterial", wrapper->RGBAToColor(100, 200, 150, 255));
+		auto anotherMaterial = baseMaterialGroup->AddMaterial("AnotherMaterial", wrapper->RGBAToColor(100, 200, 150, 255));
+
+		std::vector<sTriangleProperties> properties(mesh->GetTriangleCount());
+		for (Lib3MF_uint64 i = 0; i < mesh->GetTriangleCount(); i++) {
+			properties[i].m_ResourceID = baseMaterialGroup->GetResourceID();
+			for (int j = 0; j < 3; j++) {
+				properties[i].m_PropertyIDs[j] = ( i % (2+j) ) ? someMaterial : anotherMaterial;
+			}
+		}
+		mesh->SetAllTriangleProperties(properties);
+		mesh->SetObjectLevelProperty(baseMaterialGroup->GetResourceID(), someMaterial);
+
+		mesh->GetMetaDataGroup()->AddMetaData("", "Designer", "SomeDesigner", "xs:string", true);
+
+		auto writer = model->QueryWriter("3mf");
+		std::vector<Lib3MF_uint8> buffer;
+		writer->WriteToBuffer(buffer);
+
+		auto readModel = wrapper->CreateModel();
+		auto reader3MF = readModel->QueryReader("3mf");
+		reader3MF->ReadFromBuffer(buffer);
+
+		auto readMesh = readModel->GetMeshObjectByID(2);
+		std::vector<sTriangleProperties> readProperties;
+		readMesh->GetAllTriangleProperties(readProperties);
+
+		ASSERT_EQ(readMesh->GetTriangleCount(), mesh->GetTriangleCount());
+		for (Lib3MF_uint64 i = 0; i < readMesh->GetTriangleCount(); i++) {
+			auto readBaseMaterialGroup = readModel->GetBaseMaterialGroupByID(readProperties[i].m_ResourceID);
+			for (int j = 0; j < 3; j++) {
+				CompareColors(baseMaterialGroup->GetDisplayColor(properties[i].m_PropertyIDs[j]), baseMaterialGroup->GetDisplayColor(readProperties[i].m_PropertyIDs[j]));
+			}
+		}
+
+		Lib3MF_uint32 nObjectResourceID = 0;
+		Lib3MF_uint32 nObjectPropertyID = 0;
+		EXPECT_TRUE(readMesh->GetObjectLevelProperty(nObjectResourceID, nObjectPropertyID));
+		EXPECT_EQ(nObjectResourceID, 1);
+		EXPECT_EQ(nObjectPropertyID, someMaterial);
+
+		auto readBaseMaterialGroup = readModel->GetBaseMaterialGroupByID(nObjectResourceID);
+		CompareColors(baseMaterialGroup->GetDisplayColor(someMaterial), readBaseMaterialGroup->GetDisplayColor(nObjectPropertyID));
+	}
+
 	TEST_F(Properties, ObjectLevelPropertiesReadOnly1)
 	{
 		auto readModel = wrapper->CreateModel();


### PR DESCRIPTION
Resolves Issue #209.  In the case of duplicated metadata on the model, this change retains the first copy of the metadata, and generates a warning (but not an exception) when encountering duplicates of that metadata key.