### PR TITLE
Add missing #include <string>

### DIFF
--- a/Include/Common/Platform/NMR_XmlWriter_Native.h
+++ b/Include/Common/Platform/NMR_XmlWriter_Native.h
@@ -37,6 +37,7 @@ NMR_XmlWriter_Native.h implements an XML Writer Class without dependencies.
 #include <array>
 #include <map>
 #include <list>
+#include <string>
 
 #define NATIVEXMLSPACINGBUFFERSIZE 256
 #define NATIVEXMLSPACING 9


### PR DESCRIPTION
Fixes `error C2039: 'string': is not a member of 'std'`
when compiling with MSVC ++ from VS 2017/2019