### PR TITLE
Add pkgconfig file back to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_policy(SET CMP0048 NEW)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-project(lib3mf)
-
-
 include(GNUInstallDirs)
 
 # Define Version
@@ -15,6 +12,10 @@ set(LIB3MF_VERSION_MAJOR 2)        # increase on every backward-compatibility br
 set(LIB3MF_VERSION_MINOR 0)        # increase on every backward compatible change of the API
 set(LIB3MF_VERSION_MICRO 0)        # increase on on every change that does not alter the API
 set(LIB3MF_VERSION_PRERELEASE "")  # denotes pre-release information of a version of lib3mf
+
+project(lib3mf
+  VERSION ${LIB3MF_VERSION_MAJOR}.${LIB3MF_VERSION_MINOR}.${LIB3MF_VERSION_MICRO}
+  DESCRIPTION "An implementation of the 3D Manufacturing Format file standard")
 
 set(CMAKE_INSTALL_BINDIR bin CACHE PATH "directory for installing binary files")
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "directory for installing library files")
@@ -176,6 +177,8 @@ else()
   target_compile_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:RELEASE>:/O2;/sdl;/WX;/Oi;/Gy;/FC;/wd4996>")
 endif()
 
+configure_file(lib3mf.pc.in lib3mf.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/lib3mf.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/lib3mf.pc.in
+++ b/lib3mf.pc.in
@@ -8,5 +8,5 @@ Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
 Requires:
-Libs: -L${libdir} -l3MF -lzip -lz
+Libs: -L${libdir} -l3mf -lzip -lz
 Cflags: -I${includedir}


### PR DESCRIPTION
This makes the necessary changes to have the existing lib3MF.pc.in file built in CMake again (as removed here https://github.com/3MFConsortium/lib3mf/commit/a32e2179e47e17601fb87e898f5a010b71238d98#diff-af3b638bc2a3e6c650974192a53c7291L147-L148)

I've also changed the casing of `lib3MF` to `lib3mf` on the pc file as the package name is lower case and so is the .so file.

Fixes #224 

And here's a test script for building with pkgconfig

```bash
set -e
# from repo root
mkdir build
cd build
mkdir usr
cmake -DCMAKE_INSTALL_PREFIX=usr -DLIB3MF_TESTS=0 ..
make -j
make install

(
    cat <<EOF
#include "Bindings/C/lib3mf.h"
int main(){}
EOF
) > test.cc
flags=$(PKG_CONFIG_PATH=./usr/lib/pkgconfig pkg-config --cflags --libs lib3mf)
g++ $flags test.cc
LD_LIBRARY_PATH=./usr/lib ./a.out && echo 'SUCCESS' || echo 'FAIL'
LD_LIBRARY_PATH=./usr/lib ldd a.out

```