### PR TITLE
[spec] Decode extension properties

### DIFF
--- a/AutomaticComponentToolkit/lib3mf.xml
+++ b/AutomaticComponentToolkit/lib3mf.xml
@@ -1586,8 +1586,47 @@
 		<method name="GetKeyStore" description="Gets the keystore associated with this model">
 			<param name="KeyStore" type="handle" class="KeyStore" pass="return" description="The package keystore"/>
 		</method>
+		<method name="AddExtension" description="adds an extension to the model.">
+			<param name="URI" type="string" pass="in" description="NameSpace URI of the extension"/>
+			<param name="Prefix" type="string" pass="in" description="NameSpace prefix of the extension"/>
+			<param name="IsRequired" type="bool" pass="in" description="Whether the extensions is required or not"/>
+			<param name="ExtensionInstance" type="handle" class="Extension" pass="return" description="Instance of the extension object"/>
+		</method>
+		<method name="RemoveExtension" description="Removes extension object from the model.">
+			<param name="URI" type="string" pass="in" description="NameSpace URI of the extension"/>
+		</method>
+		<method name="GetExtension" description="retrieves an extension object from the model..">
+			<param name="Index" type="uint32" pass="in" description="Index of the extension"/>
+			<param name="ExtensionInstance" type="handle" class="Extension" pass="return" description="Instance of the extension object"/>
+		</method>
+		<method name="FindExtension" description="retrieves an extension object from the model.">
+			<param name="URI" type="string" pass="in" description="Path URI in the package"/>
+			<param name="ExtensionInstance" type="handle" class="Extension" pass="return" description="Instance of the extension object"/>
+		</method>
+		<method name="GetExtensionCount" description="retrieves the number of extensions of the model.">
+			<param name="ExtensionCount" type="uint32" pass="return" description="Returns the number of extensions."/>
+		</method>
+	</class>		
+	<class name="Extension">
+		<method name="GetNameSpaceURI" description="Returns the namespace URI.">
+			<param name="NameSpaceURI" type="string" pass="return" description="Returns the namespace URI"/>
+		</method>
+		<method name="SetNameSpaceURI" description="Sets the namespace URI.">
+			<param name="NameSpaceURI" type="string" pass="in" description=" the namespace URI."/>
+		</method>
+		<method name="GetNameSpacePrefix" description="Returns the namespace prefix.">
+			<param name="NameSpacePrefix" type="string" pass="return" description="Returns the namespace prefix"/>
+		</method>
+		<method name="SetNameSpacePrefix" description="Sets the namespace prefix.">
+			<param name="NameSpacePrefix" type="string" pass="in" description=" the namespace prefix."/>
+		</method>
+		<method name="SetIsRequired" description="Sets if the extension is required or not.">
+			<param name="IsRequired" type="bool" pass="in" description="flag whether extension is required or not."/>
+		</method>
+		<method name="GetIsRequired" description="Queries whether theextension is required or not">
+			<param name="IsRequired" type="bool" pass="return" description="returns flag whether extension is required or not or not."/>
+		</method>
 	</class>
-
 	<global baseclassname="Base" releasemethod="Release" acquiremethod="Acquire" journalmethod="SetJournal" versionmethod="GetLibraryVersion" errormethod="GetLastError" prereleasemethod="GetPrereleaseInformation" buildinfomethod="GetBuildInformation">
 		<method name="GetLibraryVersion" description="retrieves the binary version of this library.">
 			<param name="Major" type="uint32" pass="out" description="returns the major version of this library"/>

--- a/AutomaticComponentToolkit/lib3mf.xml
+++ b/AutomaticComponentToolkit/lib3mf.xml
@@ -1610,7 +1610,8 @@
 		<method name="GetExtensionCount" description="retrieves the number of extensions of the model.">
 			<param name="ExtensionCount" type="uint32" pass="return" description="Returns the number of extensions."/>
 		</method>
-	</class>		
+	</class>
+	
 	<class name="Extension">
 		<method name="GetNameSpaceURI" description="Returns the namespace URI.">
 			<param name="NameSpaceURI" type="string" pass="return" description="Returns the namespace URI"/>
@@ -1631,6 +1632,7 @@
 			<param name="IsRequired" type="bool" pass="return" description="returns flag whether extension is required or not or not."/>
 		</method>
 	</class>
+
 	<global baseclassname="Base" releasemethod="Release" acquiremethod="Acquire" journalmethod="SetJournal" versionmethod="GetLibraryVersion" errormethod="GetLastError" prereleasemethod="GetPrereleaseInformation" buildinfomethod="GetBuildInformation">
 		<method name="GetLibraryVersion" description="retrieves the binary version of this library.">
 			<param name="Major" type="uint32" pass="out" description="returns the major version of this library"/>

--- a/AutomaticComponentToolkit/lib3mf.xml
+++ b/AutomaticComponentToolkit/lib3mf.xml
@@ -1595,6 +1595,10 @@
 		<method name="RemoveExtension" description="Removes extension object from the model.">
 			<param name="URI" type="string" pass="in" description="NameSpace URI of the extension"/>
 		</method>
+		<method name="HasExtension" description="Checks if the model contains an extension with the namespace URI">
+			<param name="URI" type="string" pass="in" description="NameSpace URI of the extension"/>
+			<param name="Exists" type="bool" pass="return" description="returns flag whether the model contains an extension with the namespace URI"/>
+		</method>
 		<method name="GetExtension" description="retrieves an extension object from the model..">
 			<param name="Index" type="uint32" pass="in" description="Index of the extension"/>
 			<param name="ExtensionInstance" type="handle" class="Extension" pass="return" description="Instance of the extension object"/>

--- a/Include/API/lib3mf_extension.hpp
+++ b/Include/API/lib3mf_extension.hpp
@@ -1,0 +1,96 @@
+/*++
+
+Copyright (C) 2020 3MF Consortium (Original Author)
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract: This is the class declaration of CExtension
+
+*/
+
+
+#ifndef __LIB3MF_EXTENSION
+#define __LIB3MF_EXTENSION
+
+#include "lib3mf_interfaces.hpp"
+#include "lib3mf_base.hpp"
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4250)
+#endif
+
+// Include custom headers here.
+#include "Model/Classes/NMR_Extension.h"
+
+namespace Lib3MF {
+namespace Impl {
+
+
+/*************************************************************************************************************************
+ Class declaration of CExtension 
+**************************************************************************************************************************/
+
+class CExtension : public virtual IExtension, public virtual CBase {
+private:
+
+	/**
+	* Put private members here.
+	*/
+	NMR::PExtension m_pExtension;
+
+protected:
+
+	/**
+	* Put protected members here.
+	*/
+
+public:
+
+	/**
+	* Put additional public members here. They will not be visible in the external API.
+	*/
+	CExtension(NMR::PExtension pExtension);
+
+	/**
+	* Public member functions to implement.
+	*/
+
+	bool GetIsRequired() override;
+	void SetIsRequired(bool bIsRequired) override;
+
+	std::string GetNameSpaceURI() override;
+	void SetNameSpaceURI(const std::string & sNameSpaceURI) override;
+
+	std::string GetNameSpacePrefix() override;
+	void SetNameSpacePrefix(const std::string & sNameSpacePrefix) override;
+
+};
+
+}
+}
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#endif // __LIB3MF_EXTENSION

--- a/Include/API/lib3mf_model.hpp
+++ b/Include/API/lib3mf_model.hpp
@@ -194,6 +194,16 @@ public:
 	IKeyStore * GetKeyStore();
 
 	void SetRandomNumberCallback(const Lib3MF::RandomNumberCallback pTheCallback, const Lib3MF_pvoid pUserData);
+
+	IExtension * AddExtension(const std::string & sNameSpaceURI, const std::string & sNameSpacePrefix, bool bIsRequired) override;
+
+	void RemoveExtension(const std::string & sNameSpaceURI) override;
+
+	IExtension * GetExtension(const Lib3MF_uint32 nIndex) override;
+
+	IExtension * FindExtension(const std::string & sNameSpaceURI) override;
+
+	Lib3MF_uint32 GetExtensionCount() override;
 };
 
 }

--- a/Include/API/lib3mf_model.hpp
+++ b/Include/API/lib3mf_model.hpp
@@ -197,6 +197,8 @@ public:
 
 	IExtension * AddExtension(const std::string & sNameSpaceURI, const std::string & sNameSpacePrefix, bool bIsRequired) override;
 
+	bool HasExtension(const std::string & sNameSpaceURI) override;
+
 	void RemoveExtension(const std::string & sNameSpaceURI) override;
 
 	IExtension * GetExtension(const Lib3MF_uint32 nIndex) override;

--- a/Include/Common/NMR_ErrorConst.h
+++ b/Include/Common/NMR_ErrorConst.h
@@ -1219,6 +1219,11 @@ Model error codes (0x8XXX)
 // A beamset identifier is not unique
 #define NMR_ERROR_BEAMSET_IDENTIFIER_NOT_UNIQUE 0x810B
 
+// An extension namespace prefix is duplicated
+#define NMR_ERROR_DUPLICATE_EXTENSION_NAMESPACEPREFIX 0x810C
+
+// An extension namespace uri is duplicated
+#define NMR_ERROR_DUPLICATE_EXTENSION_NAMESPACEURI 0x810D
 
 
 

--- a/Include/Model/Classes/NMR_Extension.h
+++ b/Include/Model/Classes/NMR_Extension.h
@@ -1,0 +1,66 @@
+/*++
+
+Copyright (C) 2020 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+NMR_Extension.h defines the Extension Class.
+An extension is an in memory representation of the extensions supported by a 3MF package.
+
+--*/
+
+#include "Common/NMR_Local.h"
+#include "Common/NMR_Types.h"
+#include <string>
+
+#ifndef __NMR_EXTENSION
+#define __NMR_EXTENSION
+
+namespace NMR {
+
+	class CExtension {
+	private:
+		std::string m_sNameSpaceURI;
+		std::string m_sNameSpacePrefix;
+		nfBool m_bIsRequired;
+	public:
+		CExtension() = delete;
+		CExtension(_In_ const std::string sNameSpaceURI, _In_ std::string sNameSpacePrefix, _In_ nfBool bIsRequired);
+
+		nfBool getIsRequired();
+		void setIsRequired(_In_ nfBool bIsRequired);
+
+		std::string getNameSpaceURI();
+		void setNameSpaceURI(_In_ const std::string sNameSpaceURI);
+
+		std::string getNameSpacePrefix();
+		void setNameSpacePrefix(_In_ const std::string sNameSpacePrefix);
+	};
+
+	typedef std::shared_ptr <CExtension> PExtension;
+
+}
+
+#endif // __NMR_EXTENSION

--- a/Include/Model/Classes/NMR_Model.h
+++ b/Include/Model/Classes/NMR_Model.h
@@ -94,6 +94,9 @@ namespace NMR {
 	class CKeyStore;
 	typedef std::shared_ptr <CKeyStore> PKeyStore;
 
+	class CExtension;
+	typedef std::shared_ptr <CExtension> PExtension;
+
 	typedef std::map<NMR::UniqueResourceID, NMR::UniqueResourceID> UniqueResourceIDMapping;
 
 	// The Model class implements the unification of all model-file in a 3MF package
@@ -110,6 +113,9 @@ namespace NMR {
 		CResourceHandler m_resourceHandler;
 	private:
 		std::vector<PModelResource> m_Resources;
+
+		// Extensions
+		std::vector<PExtension> m_Extensions;
 
 		// Model Build Items
 		std::vector<PModelBuildItem> m_BuildItems;
@@ -301,6 +307,7 @@ namespace NMR {
 		nfBool contentTypeIsDefault(_In_ const std::string sExtension);
 
 		// Production Extension Attachments
+
 		PModelAttachment addProductionAttachment(_In_ const std::string sPath, _In_ const std::string sRelationShipType, PImportStream pCopiedStream, nfBool bForceUnique);
 		void removeProductionAttachment(_In_ const std::string sPath);
 		nfUint32 getProductionAttachmentCount();
@@ -326,6 +333,13 @@ namespace NMR {
 		void setCryptoRandCallback(CryptoRandGenDescriptor const & randDescriptor);
 		nfBool hasCryptoRandCallbak() const;
 		nfUint64 generateRandomBytes(nfByte *, nfUint64);
+
+		// Extensions
+		PExtension addExtension(_In_ const std::string sNameSpaceURI, _In_ std::string sNameSpacePrefix, _In_ nfBool bIsRequired);
+		void removeExtension(_In_ const std::string sNameSpaceURI);
+		nfBool hasExtension(_In_ const std::string sNameSpaceURI);
+		PExtension getExtensionByURI(_In_ const std::string sNameSpaceURI);
+		PExtension getExtensionByPrefix(_In_ const std::string sNameSpacePrefix);
 
 	};
 

--- a/Include/Model/Classes/NMR_Model.h
+++ b/Include/Model/Classes/NMR_Model.h
@@ -337,9 +337,10 @@ namespace NMR {
 		// Extensions
 		PExtension addExtension(_In_ const std::string sNameSpaceURI, _In_ std::string sNameSpacePrefix, _In_ nfBool bIsRequired);
 		void removeExtension(_In_ const std::string sNameSpaceURI);
-		nfBool hasExtension(_In_ const std::string sNameSpaceURI);
-		PExtension getExtensionByURI(_In_ const std::string sNameSpaceURI);
-		PExtension getExtensionByPrefix(_In_ const std::string sNameSpacePrefix);
+		PExtension findExtensionByURI(_In_ const std::string sNameSpaceURI);
+		PExtension findExtensionByPrefix(_In_ const std::string sNameSpacePrefix);
+		PExtension getExtension(_In_ nfUint32 nIndex);
+		nfUint32 getExtensionCount();
 
 	};
 

--- a/Include/Model/Reader/NMR_ModelReaderNode_ModelBase.h
+++ b/Include/Model/Reader/NMR_ModelReaderNode_ModelBase.h
@@ -42,7 +42,6 @@ namespace NMR {
 	protected:
 		CModel * m_pModel;
 		std::string m_sRequiredExtensions;
-		std::map<std::string, std::string> m_ListedExtensions;
 
 		std::string m_sPath;
 		nfBool m_bHasResources;

--- a/Source/API/lib3mf_extension.cpp
+++ b/Source/API/lib3mf_extension.cpp
@@ -1,0 +1,71 @@
+/*++
+
+Copyright (C) 2019 3MF Consortium (Original Author)
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract: This is a stub class definition of CExtension
+
+*/
+
+#include "lib3mf_extension.hpp"
+#include "lib3mf_interfaceexception.hpp"
+
+// Include custom headers here.
+#include "Model/Classes/NMR_Extension.h"
+
+using namespace Lib3MF::Impl;
+
+/*************************************************************************************************************************
+ Class definition of CExtension 
+**************************************************************************************************************************/
+
+CExtension::CExtension(NMR::PExtension pExtension)
+	: m_pExtension(pExtension)
+{
+	
+}
+
+bool CExtension::GetIsRequired() {
+	return m_pExtension->getIsRequired();
+}
+
+void CExtension::SetIsRequired(bool bIsRequired) {
+	m_pExtension->setIsRequired(bIsRequired);
+}
+
+std::string CExtension::GetNameSpaceURI() {
+	return m_pExtension->getNameSpaceURI();
+}
+
+void CExtension::SetNameSpaceURI(const std::string & sNameSpaceURI) {
+	m_pExtension->setNameSpaceURI(sNameSpaceURI);
+}
+
+std::string CExtension::GetNameSpacePrefix() {
+	return m_pExtension->getNameSpacePrefix();
+}
+
+void CExtension::SetNameSpacePrefix(const std::string & sNameSpacePrefix) {
+	m_pExtension->setNameSpacePrefix(sNameSpacePrefix);
+}

--- a/Source/API/lib3mf_model.cpp
+++ b/Source/API/lib3mf_model.cpp
@@ -60,6 +60,7 @@ Abstract: This is a stub class definition of CModel
 #include "lib3mf_multipropertygroupiterator.hpp"
 #include "lib3mf_packagepart.hpp"
 #include "lib3mf_keystore.hpp"
+#include "lib3mf_extension.hpp"
 
 
 // Include custom headers here.
@@ -704,5 +705,25 @@ void Lib3MF::Impl::CModel::SetRandomNumberCallback(Lib3MF::RandomNumberCallback 
 	};
 
 	m_model->setCryptoRandCallback(descriptor);
+}
+
+IExtension * Lib3MF::Impl::CModel::AddExtension(const std::string & sNameSpaceURI, const std::string & sNameSpacePrefix, bool bIsRequired) {
+	return new CExtension(m_model->addExtension(sNameSpaceURI, sNameSpacePrefix, bIsRequired));
+}
+
+void Lib3MF::Impl::CModel::RemoveExtension(const std::string & sNameSpaceURI) {
+	m_model->removeExtension(sNameSpaceURI);
+}
+
+IExtension * Lib3MF::Impl::CModel::GetExtension(const Lib3MF_uint32 nIndex) {
+	return new CExtension(m_model->getExtension(nIndex));
+}
+
+IExtension * Lib3MF::Impl::CModel::FindExtension(const std::string & sNameSpaceURI) {
+	return new CExtension(m_model->findExtensionByURI(sNameSpaceURI));
+}
+
+Lib3MF_uint32 Lib3MF::Impl::CModel::GetExtensionCount() {
+	return m_model->getExtensionCount();
 }
 

--- a/Source/API/lib3mf_model.cpp
+++ b/Source/API/lib3mf_model.cpp
@@ -715,6 +715,10 @@ void Lib3MF::Impl::CModel::RemoveExtension(const std::string & sNameSpaceURI) {
 	m_model->removeExtension(sNameSpaceURI);
 }
 
+bool Lib3MF::Impl::CModel::HasExtension(const std::string & sNameSpaceURI) {
+	return m_model->findExtensionByURI(sNameSpaceURI) != nullptr;
+}
+
 IExtension * Lib3MF::Impl::CModel::GetExtension(const Lib3MF_uint32 nIndex) {
 	return new CExtension(m_model->getExtension(nIndex));
 }

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -40,6 +40,7 @@ Source/API/lib3mf_compositematerials.cpp
 Source/API/lib3mf_compositematerialsiterator.cpp
 Source/API/lib3mf_componentsobject.cpp
 Source/API/lib3mf_componentsobjectiterator.cpp
+Source/API/lib3mf_extension.cpp
 Source/API/lib3mf_meshobject.cpp
 Source/API/lib3mf_meshobjectiterator.cpp
 Source/API/lib3mf_metadata.cpp

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -120,6 +120,7 @@ Source/Common/Platform/NMR_XmlReader.cpp
 Source/Common/Platform/NMR_XmlWriter.cpp
 Source/Common/Platform/NMR_XmlWriter_Native.cpp
 Source/Model/Classes/NMR_PackageResourceID.cpp
+Source/Model/Classes/NMR_Extension.cpp
 Source/Model/Classes/NMR_Model.cpp
 Source/Model/Classes/NMR_ModelAttachment.cpp
 Source/Model/Classes/NMR_ModelBaseMaterial.cpp

--- a/Source/Common/NMR_Exception.cpp
+++ b/Source/Common/NMR_Exception.cpp
@@ -402,6 +402,8 @@ namespace NMR {
 		case NMR_ERROR_MODELRESOURCE_IN_DIFFERENT_MODEL: return "Referenced model resource must not be in a different model.";
 		case NMR_ERROR_PATH_NOT_ABSOLUTE: return "A path attribute element is not absolute.";
 		case NMR_ERROR_BEAMSET_IDENTIFIER_NOT_UNIQUE: return "A beamset identifier is not unique.";
+		case NMR_ERROR_DUPLICATE_EXTENSION_NAMESPACEPREFIX: return "An extension namespace prefix is duplicated.";
+		case NMR_ERROR_DUPLICATE_EXTENSION_NAMESPACEURI: return "An extension namespace uri is duplicated.";
 			//keystore error codes
 		case NMR_ERROR_KEYSTOREDUPLICATECONSUMER: return "A consumer already exists for this consumerid";
 		case NMR_ERROR_KEYSTOREDUPLICATECONSUMERID: return "The attribute consumerid is duplicated";

--- a/Source/Model/Classes/NMR_Extension.cpp
+++ b/Source/Model/Classes/NMR_Extension.cpp
@@ -1,0 +1,68 @@
+/*++
+
+Copyright (C) 2020 3MF Consortium
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Abstract:
+
+NMR_Extension.cpp implements the Extension Class.
+An extension is an in memory representation of the extensions supported by a 3MF package.
+
+--*/
+
+#include "Model/Classes/NMR_Extension.h"
+
+namespace NMR {
+
+	CExtension::CExtension(_In_ const std::string sNameSpaceURI, _In_ std::string sNameSpacePrefix, _In_ nfBool bIsRequired)
+		: m_sNameSpaceURI(sNameSpaceURI), m_sNameSpacePrefix(sNameSpacePrefix), m_bIsRequired(bIsRequired)
+	{
+	}
+
+	nfBool CExtension::getIsRequired() {
+		return m_bIsRequired;
+	}
+
+	void CExtension::setIsRequired(_In_ nfBool bIsRequired) {
+		m_bIsRequired = bIsRequired;
+	}
+
+	std::string CExtension::getNameSpaceURI() {
+		return m_sNameSpaceURI;
+	}
+
+	void CExtension::setNameSpaceURI(_In_ const std::string sNameSpaceURI) {
+		m_sNameSpaceURI = sNameSpaceURI;
+	}
+
+	std::string CExtension::getNameSpacePrefix() {
+		return m_sNameSpacePrefix;
+	}
+
+	void CExtension::setNameSpacePrefix(_In_ const std::string sNameSpacePrefix) {
+		m_sNameSpacePrefix = sNameSpacePrefix;
+	}
+
+}
+

--- a/Source/Model/Classes/NMR_Model.cpp
+++ b/Source/Model/Classes/NMR_Model.cpp
@@ -1317,51 +1317,46 @@ namespace NMR {
 	}
 
 	PExtension CModel::addExtension(_In_ const std::string sNameSpaceURI, _In_ std::string sNameSpacePrefix, _In_ nfBool bIsRequired) {
+		for (auto iIterator = m_Extensions.begin(); iIterator != m_Extensions.end(); iIterator++) {
+			auto pExt = *iIterator;
+			if (pExt->getNameSpaceURI() == sNameSpaceURI) {
+				throw CNMRException(NMR_ERROR_DUPLICATE_EXTENSION_NAMESPACEURI);
+			}
+			if (pExt->getNameSpacePrefix() == sNameSpacePrefix) {
+				throw CNMRException(NMR_ERROR_DUPLICATE_EXTENSION_NAMESPACEPREFIX);
+			}
+		}
 		PExtension pExtension = std::make_shared<CExtension>(sNameSpaceURI, sNameSpacePrefix, bIsRequired);
 		m_Extensions.push_back(pExtension);
 		return pExtension;
 	}
 
 	void CModel::removeExtension(_In_ const std::string sNameSpaceURI) {
-		auto iIterator = m_Extensions.begin();
-		while (iIterator != m_Extensions.end()) {
+		for (auto iIterator = m_Extensions.begin(); iIterator != m_Extensions.end(); iIterator++) {
 			if ((*iIterator)->getNameSpaceURI() == sNameSpaceURI) {
 				m_Extensions.erase(iIterator);
-				return;
 			}
-			iIterator++;
 		}
 	}
 
 	nfBool CModel::hasExtension(_In_ const std::string sNameSpaceURI) {
-		auto iIterator = m_Extensions.begin();
-		while (iIterator != m_Extensions.end()) {
-			if ((*iIterator)->getNameSpaceURI() == sNameSpaceURI) {
-				return true;
-			}
-			iIterator++;
-		}
-		return false;
+		return getExtensionByURI(sNameSpaceURI) != nullptr;
 	}
 
 	PExtension CModel::getExtensionByURI(_In_ const std::string sNameSpaceURI) {
-		auto iIterator = m_Extensions.begin();
-		while (iIterator != m_Extensions.end()) {
+		for (auto iIterator = m_Extensions.begin(); iIterator != m_Extensions.end(); iIterator++) {
 			if ((*iIterator)->getNameSpaceURI() == sNameSpaceURI) {
 				return *iIterator;
 			}
-			iIterator++;
 		}
 		return nullptr;
 	}
 
 	PExtension CModel::getExtensionByPrefix(_In_ const std::string sNameSpacePrefix) {
-		auto iIterator = m_Extensions.begin();
-		while (iIterator != m_Extensions.end()) {
+		for (auto iIterator = m_Extensions.begin(); iIterator != m_Extensions.end(); iIterator++) {
 			if ((*iIterator)->getNameSpacePrefix() == sNameSpacePrefix) {
 				return *iIterator;
 			}
-			iIterator++;
 		}
 		return nullptr;
 	}

--- a/Source/Model/Classes/NMR_Model.cpp
+++ b/Source/Model/Classes/NMR_Model.cpp
@@ -1339,11 +1339,7 @@ namespace NMR {
 		}
 	}
 
-	nfBool CModel::hasExtension(_In_ const std::string sNameSpaceURI) {
-		return getExtensionByURI(sNameSpaceURI) != nullptr;
-	}
-
-	PExtension CModel::getExtensionByURI(_In_ const std::string sNameSpaceURI) {
+	PExtension CModel::findExtensionByURI(_In_ const std::string sNameSpaceURI) {
 		for (auto iIterator = m_Extensions.begin(); iIterator != m_Extensions.end(); iIterator++) {
 			if ((*iIterator)->getNameSpaceURI() == sNameSpaceURI) {
 				return *iIterator;
@@ -1352,7 +1348,7 @@ namespace NMR {
 		return nullptr;
 	}
 
-	PExtension CModel::getExtensionByPrefix(_In_ const std::string sNameSpacePrefix) {
+	PExtension CModel::findExtensionByPrefix(_In_ const std::string sNameSpacePrefix) {
 		for (auto iIterator = m_Extensions.begin(); iIterator != m_Extensions.end(); iIterator++) {
 			if ((*iIterator)->getNameSpacePrefix() == sNameSpacePrefix) {
 				return *iIterator;
@@ -1361,4 +1357,17 @@ namespace NMR {
 		return nullptr;
 	}
 
+	PExtension CModel::getExtension(_In_ nfUint32 nIndex)
+	{
+		nfUint32 nCount = getExtensionCount();
+		if (nIndex >= nCount)
+			throw CNMRException(NMR_ERROR_INVALIDINDEX);
+
+		return m_Extensions[nIndex];
+	}
+
+	nfUint32 CModel::getExtensionCount()
+	{
+		return (nfUint32)m_Extensions.size();
+	}
 }

--- a/Source/Model/Classes/NMR_Model.cpp
+++ b/Source/Model/Classes/NMR_Model.cpp
@@ -31,6 +31,7 @@ A model is an in memory representation of the 3MF file.
 
 --*/
 
+#include "Model/Classes/NMR_Extension.h"
 #include "Model/Classes/NMR_Model.h"
 #include "Model/Classes/NMR_ModelObject.h"
 #include "Model/Classes/NMR_ModelMeshObject.h"
@@ -1313,6 +1314,56 @@ namespace NMR {
 			*(bytes + n) = distByte(mTwister);
 		}
 		return size;
+	}
+
+	PExtension CModel::addExtension(_In_ const std::string sNameSpaceURI, _In_ std::string sNameSpacePrefix, _In_ nfBool bIsRequired) {
+		PExtension pExtension = std::make_shared<CExtension>(sNameSpaceURI, sNameSpacePrefix, bIsRequired);
+		m_Extensions.push_back(pExtension);
+		return pExtension;
+	}
+
+	void CModel::removeExtension(_In_ const std::string sNameSpaceURI) {
+		auto iIterator = m_Extensions.begin();
+		while (iIterator != m_Extensions.end()) {
+			if ((*iIterator)->getNameSpaceURI() == sNameSpaceURI) {
+				m_Extensions.erase(iIterator);
+				return;
+			}
+			iIterator++;
+		}
+	}
+
+	nfBool CModel::hasExtension(_In_ const std::string sNameSpaceURI) {
+		auto iIterator = m_Extensions.begin();
+		while (iIterator != m_Extensions.end()) {
+			if ((*iIterator)->getNameSpaceURI() == sNameSpaceURI) {
+				return true;
+			}
+			iIterator++;
+		}
+		return false;
+	}
+
+	PExtension CModel::getExtensionByURI(_In_ const std::string sNameSpaceURI) {
+		auto iIterator = m_Extensions.begin();
+		while (iIterator != m_Extensions.end()) {
+			if ((*iIterator)->getNameSpaceURI() == sNameSpaceURI) {
+				return *iIterator;
+			}
+			iIterator++;
+		}
+		return nullptr;
+	}
+
+	PExtension CModel::getExtensionByPrefix(_In_ const std::string sNameSpacePrefix) {
+		auto iIterator = m_Extensions.begin();
+		while (iIterator != m_Extensions.end()) {
+			if ((*iIterator)->getNameSpacePrefix() == sNameSpacePrefix) {
+				return *iIterator;
+			}
+			iIterator++;
+		}
+		return nullptr;
 	}
 
 }

--- a/Source/Model/Reader/NMR_ModelReaderNode_ModelBase.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderNode_ModelBase.cpp
@@ -75,7 +75,7 @@ namespace NMR {
 		std::vector<std::string> tokens{ std::istream_iterator<std::string,  char>{iss},
 			std::istream_iterator<std::string,  char>{} };
 		for (auto token : tokens) {
-			auto pExt = m_pModel->getExtensionByPrefix(token);
+			auto pExt = m_pModel->findExtensionByPrefix(token);
 			// is the extension listed?
 			if (pExt == nullptr) {
 				throw CNMRException(NMR_ERROR_INVALIDREQUIREDEXTENSIONPREFIX);

--- a/Source/Model/Reader/NMR_ModelReaderNode_ModelBase.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderNode_ModelBase.cpp
@@ -145,7 +145,13 @@ namespace NMR {
 			// lax handling here for other XML_3MF_NAMESPACE_XML-attributes
 		}
 		else if (strcmp(pNameSpace, XML_3MF_NAMESPACE_XMLNS) == 0) {
-			m_pModel->addExtension(pAttributeValue, pAttributeName, false);
+			auto pExt = m_pModel->findExtensionByURI(pAttributeValue);
+			if (pExt == nullptr) {
+				m_pModel->addExtension(std::string(pAttributeValue), std::string(pAttributeName), false);
+			} else {
+				// If it already exists just update the prefix so it matches with what the xml expects.
+				pExt->setNameSpacePrefix(std::string(pAttributeName));
+			}
 		}
 	}
 

--- a/Source/Model/Reader/NMR_ModelReaderNode_ModelBase.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderNode_ModelBase.cpp
@@ -40,6 +40,7 @@ A model reader node is an abstract base class for all XML nodes of a 3MF Model S
 #include "Model/Reader/v093/NMR_ModelReaderNode093_Build.h" 
 
 #include "Model/Classes/NMR_ModelConstants.h" 
+#include "Model/Classes/NMR_Extension.h" 
 #include "Common/3MF_ProgressMonitor.h"
 #include "Common/NMR_Exception.h"
 #include "Common/NMR_StringUtils.h"
@@ -74,12 +75,15 @@ namespace NMR {
 		std::vector<std::string> tokens{ std::istream_iterator<std::string,  char>{iss},
 			std::istream_iterator<std::string,  char>{} };
 		for (auto token : tokens) {
+			auto pExt = m_pModel->getExtensionByPrefix(token);
 			// is the extension listed?
-			if (m_ListedExtensions.count(token) < 1) {
+			if (pExt == nullptr) {
 				throw CNMRException(NMR_ERROR_INVALIDREQUIREDEXTENSIONPREFIX);
 			}
+
+			pExt->setIsRequired(true);
 			// is the extension supported?
-			std::string sExtensionURI = m_ListedExtensions[token];
+			auto sExtensionURI = pExt->getNameSpaceURI();
 			if (strcmp(sExtensionURI.c_str(), PACKAGE_XMLNS_100) != 0 &&
 				strcmp(sExtensionURI.c_str(), XML_3MF_NAMESPACE_MATERIALSPEC) != 0 &&
 				strcmp(sExtensionURI.c_str(), XML_3MF_NAMESPACE_PRODUCTIONSPEC) != 0 &&
@@ -141,7 +145,7 @@ namespace NMR {
 			// lax handling here for other XML_3MF_NAMESPACE_XML-attributes
 		}
 		else if (strcmp(pNameSpace, XML_3MF_NAMESPACE_XMLNS) == 0) {
-			m_ListedExtensions.insert(std::pair<std::string, std::string>(std::string(pAttributeName), std::string(pAttributeValue)));
+			m_pModel->addExtension(pAttributeValue, pAttributeName, false);
 		}
 	}
 

--- a/Tests/CPP_Bindings/Source/Model.cpp
+++ b/Tests/CPP_Bindings/Source/Model.cpp
@@ -175,4 +175,45 @@ namespace Lib3MF
 		ASSERT_EQ(oldID, newId);
 	}
 
+	TEST_F(Model, AddExtension)
+	{
+		std::string spec_uri("https://example.com/");
+		std::string spec_prefix("ex");
+		auto pExt = m_pModel->AddExtension(spec_uri, spec_prefix, true);
+		auto newExt = m_pModel->FindExtension(spec_uri);
+
+		ASSERT_EQ(pExt->GetNameSpaceURI(), spec_uri);
+		ASSERT_EQ(pExt->GetNameSpacePrefix(), spec_prefix);
+		ASSERT_TRUE(pExt->GetIsRequired());
+		ASSERT_EQ(newExt->GetNameSpaceURI(), spec_uri);
+		ASSERT_EQ(newExt->GetNameSpacePrefix(), spec_prefix);
+		ASSERT_TRUE(newExt->GetIsRequired());
+	}
+
+	TEST_F(Model, GetExtension)
+	{;
+		auto pExt1 = m_pModel->AddExtension("spec0", "s0", true);
+		auto pExt2 = m_pModel->AddExtension("spec1", "s1", true);
+
+		ASSERT_EQ(m_pModel->GetExtensionCount(), 2);
+		ASSERT_EQ(m_pModel->GetExtension(0)->GetNameSpaceURI(), "spec0");
+		ASSERT_EQ(m_pModel->GetExtension(1)->GetNameSpaceURI(), "spec1");
+	}
+
+	TEST_F(Model, ModifyExtension)
+	{
+		std::string spec_uri("https://example.com/");
+		auto pExt = m_pModel->AddExtension(spec_uri, "ex", true);
+		auto newExt = m_pModel->FindExtension(spec_uri);
+
+		std::string new_spec_uri("https://example2.com/");
+		std::string new_spec_prefix("ex2");
+		newExt->SetNameSpaceURI(new_spec_uri);
+		newExt->SetNameSpacePrefix(new_spec_prefix);
+		newExt->SetIsRequired(false);
+		
+		ASSERT_EQ(pExt->GetNameSpaceURI(), new_spec_uri);
+		ASSERT_EQ(pExt->GetNameSpacePrefix(), new_spec_prefix);
+		ASSERT_FALSE(pExt->GetIsRequired());
+	}
 }

--- a/Tests/CPP_Bindings/Source/ProductionExtension.cpp
+++ b/Tests/CPP_Bindings/Source/ProductionExtension.cpp
@@ -97,6 +97,11 @@ namespace Lib3MF
 		auto reader3MF = model->QueryReader("3mf");
 		reader3MF->ReadFromBuffer(buffer);
 		CheckReaderWarnings(reader3MF, 0);
+
+		ASSERT_TRUE(model->HasExtension("http://schemas.microsoft.com/3dmanufacturing/production/2015/06"));
+		auto pExt = model->FindExtension("http://schemas.microsoft.com/3dmanufacturing/production/2015/06");
+		ASSERT_EQ(pExt->GetNameSpacePrefix(), "p");
+		ASSERT_TRUE(pExt->GetIsRequired());
 	}
 
 	//TEST_F(ProductionExtension, ReadWrite)

--- a/Tests/CPP_Bindings/Source/Reader.cpp
+++ b/Tests/CPP_Bindings/Source/Reader.cpp
@@ -63,6 +63,23 @@ namespace Lib3MF
 	{
 		Reader::reader3MF->ReadFromFile(sTestFilesPath + "/Reader/" + "Pyramid.3mf");
 		CheckReaderWarnings(Reader::reader3MF, 0);
+		
+		ASSERT_TRUE(model->HasExtension("http://schemas.microsoft.com/3dmanufacturing/material/2015/02"));
+		ASSERT_TRUE(model->HasExtension("http://schemas.microsoft.com/3dmanufacturing/production/2015/06"));
+		ASSERT_TRUE(model->HasExtension("http://schemas.microsoft.com/3dmanufacturing/slice/2015/07"));
+
+		PExtension pExt = nullptr;
+		pExt = model->FindExtension("http://schemas.microsoft.com/3dmanufacturing/material/2015/02");
+		ASSERT_EQ(pExt->GetNameSpacePrefix(), "m");
+		ASSERT_FALSE(pExt->GetIsRequired());
+
+		pExt = model->FindExtension("http://schemas.microsoft.com/3dmanufacturing/production/2015/06");
+		ASSERT_EQ(pExt->GetNameSpacePrefix(), "p");
+		ASSERT_FALSE(pExt->GetIsRequired());
+
+		pExt = model->FindExtension("http://schemas.microsoft.com/3dmanufacturing/slice/2015/07");
+		ASSERT_EQ(pExt->GetNameSpacePrefix(), "s");
+		ASSERT_FALSE(pExt->GetIsRequired());
 	}
 
 	TEST_F(Reader, STLReadFromFile)


### PR DESCRIPTION
This PR is a tiny first step to support [d]encoding custom specifications.

It adds support for representing in memory which extensions are defined in the model file, their local prefix and whether if they are required or not.

The current decoding behavior is not changed.

The encoding does not honor the extensions defined in the model, it will come in a future PR as it requires some small refactors.