### PR TITLE
Add test coverage analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,8 @@ jobs:
         with:
           name: codecoverage.zip
           path: build/codecoverage.zip
-      - name: Archive Code Coverage Index
-        uses: actions/upload-artifact@v2
-        with:
-          name: index.html
-          path: build/codecoverage/index.html
-      - uses: codecov/codecov-action@v1
+      - name: Upload code coverage to codecov
+        uses: codecov/codecov-action@v1
         with:
           files: ./build/Test_CPP_Bindings_filtered.info
           fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           name: lib3mf.dylib
           path: build/lib3mf.dylib
+
   codecoverage-macos:
     runs-on: macos-10.15
     steps:
@@ -65,6 +66,11 @@ jobs:
         with:
           name: index.html
           path: build/codecoverage/index.html
+      - uses: codecov/codecov-action@v1
+        with:
+          files: ./build/Test_CPP_Bindings_filtered.info
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
           
   build-windows-release:
     runs-on: windows-2019

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ jobs:
         run: |
           brew install lcov
           brew install gcovr
-          brew install gcov 
       - run: sh cmake/GenerateMake.sh -DBUILD_FOR_CODECOVERAGE=ON
       - run: cmake --build .
         working-directory: ./build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,27 @@ jobs:
         with:
           name: lib3mf.dylib
           path: build/lib3mf.dylib
+  codecoverage-macos:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - run: sh cmake/GenerateMake.sh -DBUILD_FOR_CODECOVERAGE=ON
+      - run: cmake --build .
+        working-directory: ./build
+      - run: ./Tests/codecoverage/run_codecoverage.sh
+      - name: Archive Code Coverage Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: codecoverage.zip
+          path: build/codecoverage.zip
+      - name: Archive Code Coverage Index
+        uses: actions/upload-artifact@v2
+        with:
+          name: index.html
+          path: build/codecoverage/index.html
+          
   build-windows-release:
     runs-on: windows-2019
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install Prerequisites
+        run: |
+          brew install lcov
+          brew install gcovr
+          brew install gcov 
       - run: sh cmake/GenerateMake.sh -DBUILD_FOR_CODECOVERAGE=ON
       - run: cmake --build .
         working-directory: ./build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(USE_INCLUDED_ZLIB "Use included zlib" ON)
 option(USE_INCLUDED_LIBZIP "Use included libzip" ON)
 option(USE_INCLUDED_GTEST "Used included gtest" ON)
 option(USE_INCLUDED_SSL "Use included libressl" ON)
+option(BUILD_FOR_CODECOVERAGE "Build for code coverage analysis" OFF)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # using GCC
@@ -52,6 +53,13 @@ if (${MSVC})
   # set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
   # set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
 endif()
+
+if (BUILD_FOR_CODECOVERAGE)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -Wall -fprofile-arcs -ftest-coverage -DCREATEJOURNAL")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -Wall -W -fprofile-arcs -ftest-coverage")
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
+endif()
+
 
 ### The API generation target
 if(CMAKE_HOST_UNIX)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Version 2.2.0-develop](https://img.shields.io/static/v1.svg?label=lib3mf&message=v2.2.0-develop&color=green)]()
 [![Supported platforms](https://img.shields.io/static/v1.svg?label=platform&message=windows%20%7C%20macos%20%7C%20linux&color=lightgrey)]()
 [![Simplified BSD License](https://img.shields.io/static/v1.svg?label=license&message=BSD&color=green)](LICENSE)
+[![codecov](https://codecov.io/gh/3MFConsortium/lib3mf/branch/develop/graph/badge.svg?token=3ARnBye33c)](https://codecov.io/gh/3MFConsortium/lib3mf)
 
 lib3mf is a C++ implementation of the 3D Manufacturing Format file standard.
 

--- a/Tests/CPP_Bindings/Include/UnitTest_Utilities.h
+++ b/Tests/CPP_Bindings/Include/UnitTest_Utilities.h
@@ -64,6 +64,18 @@ catch (const type &) {\
 }
 
 
+class Lib3MFTest : public ::testing::Test {
+	public:
+	static void SetUpTestCase() {
+		wrapper = Lib3MF::CWrapper::loadLibrary();
+		#ifdef CREATEJOURNAL
+		wrapper->SetJournal("journal.txt");
+		#endif
+	}
+	static Lib3MF::PWrapper wrapper;
+};
+	
+
 inline std::vector<Lib3MF_uint8> ReadFileIntoBuffer(std::string sFileName)
 {
 	// Read the file fully into a memory buffer

--- a/Tests/CPP_Bindings/Source/Attachments.cpp
+++ b/Tests/CPP_Bindings/Source/Attachments.cpp
@@ -35,7 +35,7 @@ UnitTest_Attachments.cpp: Defines Unittests for handling of attachments
 
 namespace Lib3MF
 {
-	class AttachmentsT : public ::testing::Test {
+	class AttachmentsT : public Lib3MFTest {
 	protected:
 		const std::string m_sFolderName;
 		const std::string m_sFilenameReadWrite;
@@ -66,12 +66,7 @@ namespace Lib3MF
 		}
 
 		PModel model;
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper AttachmentsT::wrapper;
 
 	TEST_F(AttachmentsT, AddRemove)
 	{

--- a/Tests/CPP_Bindings/Source/BaseMaterialGroup.cpp
+++ b/Tests/CPP_Bindings/Source/BaseMaterialGroup.cpp
@@ -35,7 +35,7 @@ UnitTest_BaseMaterialGroup.cpp: Defines Unittests for the BaseMaterialGroup clas
 
 namespace Lib3MF
 {
-	class BaseMaterialGroup : public ::testing::Test {
+	class BaseMaterialGroup : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -48,13 +48,7 @@ namespace Lib3MF
 
 		PModel model;
 		PBaseMaterialGroup baseMaterialGroup;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper BaseMaterialGroup::wrapper;
 
 	TEST_F(BaseMaterialGroup, GetCount)
 	{

--- a/Tests/CPP_Bindings/Source/BeamLattice.cpp
+++ b/Tests/CPP_Bindings/Source/BeamLattice.cpp
@@ -35,7 +35,7 @@ UnitTest_BeamLattice.cpp: Defines Unittests for the BeamLattice class
 
 namespace Lib3MF
 {
-	class BeamLattice : public ::testing::Test {
+	class BeamLattice : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -66,15 +66,7 @@ namespace Lib3MF
 		PMeshObject otherMesh;
 		PMeshObject meshAfter;
 		PBeamLattice beamLattice;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-	public:
-		static PWrapper wrapper;
 	};
-	PWrapper BeamLattice::wrapper;
-	
 
 	TEST_F(BeamLattice, MinLength)
 	{

--- a/Tests/CPP_Bindings/Source/BeamSets.cpp
+++ b/Tests/CPP_Bindings/Source/BeamSets.cpp
@@ -35,7 +35,7 @@ UnitTest_BeamSets.cpp: Defines Unittests for the BeamSet class
 
 namespace Lib3MF
 {
-	class BeamSet : public ::testing::Test {
+	class BeamSet : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -87,13 +87,7 @@ namespace Lib3MF
 		PModel model;
 		PMeshObject mesh;
 		PBeamLattice beamLattice;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper BeamSet::wrapper;
 	
 	TEST_F(BeamSet, Name)
 	{

--- a/Tests/CPP_Bindings/Source/BuildItems.cpp
+++ b/Tests/CPP_Bindings/Source/BuildItems.cpp
@@ -35,7 +35,7 @@ UnitTest_BuildItems.cpp: Defines Unittests for the BuildItems class
 
 namespace Lib3MF
 {
-	class BuildItems : public ::testing::Test {
+	class BuildItems : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -49,13 +49,7 @@ namespace Lib3MF
 	
 		PModel model;
 		static std::string InFolder;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper BuildItems::wrapper;
 
 	std::string BuildItems::InFolder(sTestFilesPath + "/BuildItems/");
 

--- a/Tests/CPP_Bindings/Source/ColorGroup.cpp
+++ b/Tests/CPP_Bindings/Source/ColorGroup.cpp
@@ -35,7 +35,7 @@ UnitTest_ColorGroup.cpp: Defines Unittests for the ColorGroup class
 
 namespace Lib3MF
 {
-	class ColorGroup : public ::testing::Test {
+	class ColorGroup : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -48,12 +48,7 @@ namespace Lib3MF
 
 		PModel model;
 		PColorGroup colorGroup;
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper ColorGroup::wrapper;
 
 	TEST_F(ColorGroup, GetCount)
 	{

--- a/Tests/CPP_Bindings/Source/CompositeMaterials.cpp
+++ b/Tests/CPP_Bindings/Source/CompositeMaterials.cpp
@@ -35,7 +35,7 @@ UnitTest_CompositeMaterials.cpp: Defines Unittests for Composite Materials
 
 namespace Lib3MF
 {
-	class CompositeMaterials : public ::testing::Test {
+	class CompositeMaterials : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -77,13 +77,7 @@ namespace Lib3MF
 		PModel model;
 		PMeshObject mesh;
 		PBaseMaterialGroup baseMaterialGroup1, baseMaterialGroup2;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper CompositeMaterials::wrapper;
 
 	TEST_F(CompositeMaterials, Create)
 	{

--- a/Tests/CPP_Bindings/Source/EncryptionMethods.cpp
+++ b/Tests/CPP_Bindings/Source/EncryptionMethods.cpp
@@ -6,7 +6,7 @@
 
 namespace Lib3MF {
 
-	class EncryptionMethods : public ::testing::Test {
+	class EncryptionMethods : public Lib3MFTest {
 	protected:
 		PModel model;
 		PEVP_PKEY privateKey;
@@ -26,12 +26,6 @@ namespace Lib3MF {
 		virtual ~EncryptionMethods() {
 			//attempt to solve leaks
 			EncryptionCallbacks::cleanup();
-		}
-
-		static PWrapper wrapper;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
 		}
 
 		virtual void SetUp() {
@@ -144,8 +138,6 @@ namespace Lib3MF {
 			}
 		}
 	};
-
-	PWrapper EncryptionMethods::wrapper;
 	
 	TEST_F(EncryptionMethods, RemoveEncryptionFromResource) {
 

--- a/Tests/CPP_Bindings/Source/MergeModels.cpp
+++ b/Tests/CPP_Bindings/Source/MergeModels.cpp
@@ -35,7 +35,7 @@ UnitTest_Model.cpp: Defines Unittests for the functionality to merge models
 
 namespace Lib3MF
 {
-	class MergeModels : public ::testing::Test {
+	class MergeModels : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			m_pModel = wrapper->CreateModel();
@@ -47,12 +47,7 @@ namespace Lib3MF
 		}
 
 		PModel m_pModel;
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper MergeModels::wrapper;
 
 	void ExpectEqModels(PModel p1, PModel p2)
 	{

--- a/Tests/CPP_Bindings/Source/MeshObject.cpp
+++ b/Tests/CPP_Bindings/Source/MeshObject.cpp
@@ -35,22 +35,9 @@ UnitTest_MeshObject.cpp: Defines Unittests for the mesh object class
 
 namespace Lib3MF
 {
-	class MeshObject : public ::testing::Test {
+	class MeshObject : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
-			model = wrapper->CreateModel();
-			mesh = model->AddMeshObject();
-		}
-		virtual void TearDown() {
-			model.reset();
-		}
-	
-		static PModel model;
-		static PMeshObject mesh;
-		static sPosition pVertices[8];
-		static sTriangle pTriangles[12];
-
-		static void SetUpTestCase() {
 			float fSizeX = 100.0f;
 			float fSizeY = 200.0f;
 			float fSizeZ = 300.0f;
@@ -78,12 +65,25 @@ namespace Lib3MF
 			pTriangles[9] = fnCreateTriangle(6, 5, 1);
 			pTriangles[10] = fnCreateTriangle(3, 0, 4);
 			pTriangles[11] = fnCreateTriangle(4, 7, 3);
+			
+			model = wrapper->CreateModel();
+			mesh = model->AddMeshObject();
+		}
+		virtual void TearDown() {
+			model.reset();
+		}
+	
+		static PModel model;
+		static PMeshObject mesh;
+		static sPosition pVertices[8];
+		static sTriangle pTriangles[12];
+
+		static void SetUpTestCase() {
+
 
 			wrapper = CWrapper::loadLibrary();
 		}
-		static PWrapper wrapper;
 	};
-	PWrapper MeshObject::wrapper;
 
 	PModel MeshObject::model;
 	PMeshObject MeshObject::mesh;

--- a/Tests/CPP_Bindings/Source/MetaData.cpp
+++ b/Tests/CPP_Bindings/Source/MetaData.cpp
@@ -35,7 +35,7 @@ UnitTest_MetaData.cpp: Defines Unittests for the MetaData class
 
 namespace Lib3MF
 {
-	class MetaData : public ::testing::Test {
+	class MetaData : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -50,14 +50,8 @@ namespace Lib3MF
 		PModel model;
 		PMetaDataGroup metaDataGroup;
 		PMetaData metaData;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper MetaData::wrapper;
-
+	
 	TEST_F(MetaData, DefaultNameSpace)
 	{
 		auto md = metaDataGroup->AddMetaData("", "Designer", "SomeDesigner", "xs:string", true);

--- a/Tests/CPP_Bindings/Source/MetaDataGroup.cpp
+++ b/Tests/CPP_Bindings/Source/MetaDataGroup.cpp
@@ -35,7 +35,7 @@ UnitTest_MetaDataGroup.cpp: Defines Unittests for the MetaDataGroup class
 
 namespace Lib3MF
 {
-	class MetaDataGroup : public ::testing::Test {
+	class MetaDataGroup : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -51,12 +51,7 @@ namespace Lib3MF
 		PReader reader;
 		PWriter writer;
 		static std::string m_sFolderName;
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper MetaDataGroup::wrapper;
 
 	std::string MetaDataGroup::m_sFolderName("TestOutput");
 

--- a/Tests/CPP_Bindings/Source/Model.cpp
+++ b/Tests/CPP_Bindings/Source/Model.cpp
@@ -35,7 +35,7 @@ UnitTest_Model.cpp: Defines Unittests for the Model classes
 
 namespace Lib3MF
 {
-	class Model : public ::testing::Test {
+	class Model : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			m_pModel = wrapper->CreateModel();

--- a/Tests/CPP_Bindings/Source/MultiProperties.cpp
+++ b/Tests/CPP_Bindings/Source/MultiProperties.cpp
@@ -35,7 +35,7 @@ UnitTest_MultiProperties.cpp: Defines Unittests for MultiProperties
 
 namespace Lib3MF
 {
-	class MultiProperties : public ::testing::Test {
+	class MultiProperties : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -107,12 +107,7 @@ namespace Lib3MF
 		PTexture2DGroup texture2DGroup;
 
 		void setupMultiPropertyGroup(PMultiPropertyGroup multiPropertyGroup);
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper MultiProperties::wrapper;
 
 	TEST_F(MultiProperties, Create)
 	{

--- a/Tests/CPP_Bindings/Source/Object.cpp
+++ b/Tests/CPP_Bindings/Source/Object.cpp
@@ -35,7 +35,7 @@ UnitTest_Object.cpp: Defines Unittests for the object class and its descendants
 
 namespace Lib3MF
 {
-	class ObjectT : public ::testing::Test {
+	class ObjectT : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -45,13 +45,7 @@ namespace Lib3MF
 		}
 	
 		PModel model;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper ObjectT::wrapper;
 
 	TEST_F(ObjectT, AddMesh)
 	{
@@ -156,7 +150,7 @@ namespace Lib3MF
 	}
 
 
-	class ObjectAssembled : public ::testing::Test {
+	class ObjectAssembled : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -208,7 +202,7 @@ namespace Lib3MF
 	}
 
 
-	class ObjectSingle : public ::testing::Test {
+	class ObjectSingle : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -310,7 +304,7 @@ namespace Lib3MF
 	}
 
 
-	class ObjectThumbnail : public ::testing::Test {
+	class ObjectThumbnail : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();

--- a/Tests/CPP_Bindings/Source/Outbox.cpp
+++ b/Tests/CPP_Bindings/Source/Outbox.cpp
@@ -35,7 +35,7 @@ UnitTest_Object.cpp: Defines Unittests for the object class and its descendants
 
 namespace Lib3MF
 {
-	class Outbox : public ::testing::Test {
+	class Outbox : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -47,13 +47,7 @@ namespace Lib3MF
 		}
 	
 		PModel model;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper Outbox::wrapper;
 
 	void CompareBoxes(Lib3MF::sBox boxA, Lib3MF::sBox boxB) {
 		for (int i = 0; i < 3; i++) {

--- a/Tests/CPP_Bindings/Source/ProductionExtension.cpp
+++ b/Tests/CPP_Bindings/Source/ProductionExtension.cpp
@@ -36,7 +36,7 @@ classes
 
 namespace Lib3MF
 {
-	class ProductionExtension : public ::testing::Test {
+	class ProductionExtension : public Lib3MFTest {
 	protected:
 		sPosition pVertices[8];
 		sTriangle pTriangles[12];
@@ -76,13 +76,7 @@ namespace Lib3MF
 		}
 
 		PModel model;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper ProductionExtension::wrapper;
 
 	TEST_F(ProductionExtension, ManipulatePaths)
 	{

--- a/Tests/CPP_Bindings/Source/ProgressCallback.cpp
+++ b/Tests/CPP_Bindings/Source/ProgressCallback.cpp
@@ -35,7 +35,7 @@ UnitTest_Writer.cpp: Defines Unittests for the Writer classes
 
 namespace Lib3MF
 {
-	class ProgressCallbackTest : public ::testing::Test {
+	class ProgressCallbackTest : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -55,13 +55,7 @@ namespace Lib3MF
 		static std::string OutFolder;
 	public:
 		static void* m_spUserData;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper ProgressCallbackTest::wrapper;
 
 	PModel ProgressCallbackTest::model;
 	std::string ProgressCallbackTest::InFolder(sTestFilesPath + "/Writer/");

--- a/Tests/CPP_Bindings/Source/Properties.cpp
+++ b/Tests/CPP_Bindings/Source/Properties.cpp
@@ -35,7 +35,7 @@ UnitTest_Properties.cpp: Defines Unittests for the color and basematerial proper
 
 namespace Lib3MF
 {
-	class Properties : public ::testing::Test {
+	class Properties : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -55,14 +55,7 @@ namespace Lib3MF
 
 		PModel model;
 		PMeshObject mesh;
-
-		static void SetUpTestCase() {
-			wrapper = wrapper->loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper Properties::wrapper;
-
 
 	TEST_F(Properties, GetProperties)
 	{
@@ -325,7 +318,7 @@ namespace Lib3MF
 		writer->WriteToBuffer(buffer);
 	}
 
-	class Properties_BaseMaterial : public ::testing::Test {
+	class Properties_BaseMaterial : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -390,7 +383,7 @@ namespace Lib3MF
 
 
 
-	class Properties_Color : public ::testing::Test {
+	class Properties_Color : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {

--- a/Tests/CPP_Bindings/Source/Reader.cpp
+++ b/Tests/CPP_Bindings/Source/Reader.cpp
@@ -35,7 +35,7 @@ UnitTest_Reader.cpp: Defines Unittests for the Reader classes
 
 namespace Lib3MF
 {
-	class Reader : public ::testing::Test {
+	class Reader : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -51,13 +51,7 @@ namespace Lib3MF
 		PModel model;
 		PReader reader3MF;
 		PReader readerSTL;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper Reader::wrapper;
 
 	TEST_F(Reader, 3MFReadFromFile)
 	{

--- a/Tests/CPP_Bindings/Source/SecureContent.cpp
+++ b/Tests/CPP_Bindings/Source/SecureContent.cpp
@@ -6,7 +6,7 @@
 
 namespace Lib3MF {
 
-	class SecureContentT : public ::testing::Test {
+	class SecureContentT : public Lib3MFTest {
 	protected:
 		sPosition pVertices[8];
 		sTriangle pTriangles[12];
@@ -62,10 +62,6 @@ namespace Lib3MF {
 			model.reset();
 		}
 
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-
 		PReader readKeyStore(std::string filename) {
 			auto reader = model->QueryReader("3mf");
 			KEKCallbackData kekData;
@@ -85,9 +81,6 @@ namespace Lib3MF {
 			return readKeyStore(UNENCRYPTEDKEYSTORE);
 		}
 	public:
-
-		static PWrapper wrapper;
-
 		static void notRandomBytesAtAll(Lib3MF_uint64 byteData, Lib3MF_uint64 size, Lib3MF_pvoid userData, Lib3MF_uint64 * bytesWritten) {
 			static Lib3MF_uint8 random = 0;
 			Lib3MF_uint8 * buffer = (Lib3MF_uint8 *)byteData;
@@ -246,8 +239,6 @@ namespace Lib3MF {
 			}
 		}
 	};
-	PWrapper SecureContentT::wrapper;
-
 	
 
 	using Lib3MF_buffer = std::vector<Lib3MF_uint8>;

--- a/Tests/CPP_Bindings/Source/Slice.cpp
+++ b/Tests/CPP_Bindings/Source/Slice.cpp
@@ -35,7 +35,7 @@ UnitTest_Slice.cpp: Defines Unittests for the Slice class
 
 namespace Lib3MF
 {
-	class Slice : public ::testing::Test {
+	class Slice : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -84,14 +84,8 @@ namespace Lib3MF
 		std::vector<Lib3MF_uint32> vEmptyPolygon;
 
 		std::vector<Lib3MF_uint32> vInvalidPolygon;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper Slice::wrapper;
-
+	
 	TEST_F(Slice, Properties)
 	{
 		ASSERT_DOUBLE_EQ(slice->GetZTop(), 1.0);

--- a/Tests/CPP_Bindings/Source/SliceStack.cpp
+++ b/Tests/CPP_Bindings/Source/SliceStack.cpp
@@ -37,7 +37,7 @@ UnitTest_SliceStack.cpp: Defines Unittests for the SliceStack class
 
 namespace Lib3MF
 {
-	class SliceStack : public ::testing::Test {
+	class SliceStack : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -53,14 +53,7 @@ namespace Lib3MF
 		PModel model;
 		PSliceStack sliceStack;
 		PMeshObject mesh;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper SliceStack::wrapper;
-
 
 	TEST_F(SliceStack, HasSetClearSliceStack)
 	{
@@ -126,7 +119,7 @@ namespace Lib3MF
 	}
 
 
-	class SliceStackArrangement : public ::testing::Test {
+	class SliceStackArrangement : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -249,7 +242,7 @@ namespace Lib3MF
 	}
 
 
-	class SliceStackWriting : public ::testing::Test {
+	class SliceStackWriting : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -397,7 +390,7 @@ namespace Lib3MF
 
 
 
-	class SliceStackReading : public ::testing::Test {
+	class SliceStackReading : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -508,7 +501,7 @@ namespace Lib3MF
 	}
 
 
-	class SliceStackTransform : public ::testing::Test {
+	class SliceStackTransform : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();

--- a/Tests/CPP_Bindings/Source/TextureProperty.cpp
+++ b/Tests/CPP_Bindings/Source/TextureProperty.cpp
@@ -35,7 +35,7 @@ UnitTest_TextureProperties.cpp: Defines Unittests for texture properties
 
 namespace Lib3MF
 {
-	class TextureProperty : public ::testing::Test {
+	class TextureProperty : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -64,13 +64,8 @@ namespace Lib3MF
 		PMeshObject mesh;
 		PAttachment textureAttachment;
 		PTexture2D texture2D;
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper TextureProperty::wrapper;
-
+	
 	TEST_F(TextureProperty, SetGet_Texture2DGroup)
 	{
 		std::vector<sTex2Coord> coords(0);

--- a/Tests/CPP_Bindings/Source/TextureResources.cpp
+++ b/Tests/CPP_Bindings/Source/TextureResources.cpp
@@ -35,7 +35,7 @@ UnitTest_TextureResources.cpp: Defines Unittests for the Texture Resource class
 
 namespace Lib3MF
 {
-	class Model_TextureResource : public ::testing::Test {
+	class Model_TextureResource : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -59,13 +59,7 @@ namespace Lib3MF
 		std::string m_sRelationshipType;
 		std::string m_sRelationshipType_Texture;
 		std::string m_sPath_Texture;
-
-		static void SetUpTestCase() {
-			wrapper = wrapper->loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper Model_TextureResource::wrapper;
 
 	TEST_F(Model_TextureResource, AddTexture)
 	{
@@ -84,7 +78,7 @@ namespace Lib3MF
 		ASSERT_SPECIFIC_THROW(texture->SetAttachment(otherAttachment.get()), ELib3MFException);
 	}
 
-	class Model_TextureResources : public ::testing::Test {
+	class Model_TextureResources : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {
@@ -165,7 +159,7 @@ namespace Lib3MF
 		ASSERT_EQ(count, 3);
 	}
 
-	class TextureResource : public ::testing::Test {
+	class TextureResource : public Lib3MFTest {
 	protected:
 
 		virtual void SetUp() {

--- a/Tests/CPP_Bindings/Source/UnitTest_Utilities.cpp
+++ b/Tests/CPP_Bindings/Source/UnitTest_Utilities.cpp
@@ -33,6 +33,8 @@ UnitTest_Utilities.cpp: Implementtion of Utilities for UnitTests
 
 #include "UnitTest_Utilities.h"
 
+Lib3MF::PWrapper Lib3MFTest::wrapper;
+
 void fnCreateBox(std::vector<Lib3MF::sPosition> &vctVertices, std::vector<Lib3MF::sTriangle> &vctTriangles) {
 	float fSizeX = 100.0f;
 	float fSizeY = 100.0f;

--- a/Tests/CPP_Bindings/Source/Wrapper.cpp
+++ b/Tests/CPP_Bindings/Source/Wrapper.cpp
@@ -39,21 +39,27 @@ operations
 
 namespace Lib3MF
 {
-	PWrapper wrapper = CWrapper::loadLibrary();
+	class Wrapper : public Lib3MFTest {
+	protected:
+		virtual void SetUp() {
+		}
+		virtual void TearDown() {
+		}
+	};
 
 	TEST(Wrapper, GetLibraryVersion)
 	{
 		Lib3MF_uint32 nMajor, nMinor, nMicro;
-		wrapper->GetLibraryVersion(nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetLibraryVersion(nMajor, nMinor, nMicro);
 
 		ASSERT_EQ(nMajor, LIB3MF_VERSION_MAJOR);
 		ASSERT_EQ(nMinor, LIB3MF_VERSION_MINOR);
 		ASSERT_EQ(nMicro, LIB3MF_VERSION_MICRO);
 
 		std::string sPreReleaseInfo, sBuildInfo;
-		wrapper->GetPrereleaseInformation(sPreReleaseInfo);
+		Lib3MFTest::wrapper->GetPrereleaseInformation(sPreReleaseInfo);
 		ASSERT_TRUE(sPreReleaseInfo == LIB3MF_VERSION_PRERELEASEINFO);
-		wrapper->GetBuildInformation(sBuildInfo);
+		Lib3MFTest::wrapper->GetBuildInformation(sBuildInfo);
 		ASSERT_TRUE(sBuildInfo == LIB3MF_VERSION_BUILDINFO);
 	}
 	
@@ -62,40 +68,40 @@ namespace Lib3MF
 		Lib3MF_uint32 nMajor, nMinor, nMicro;
 		bool bIsSupported;
 
-		wrapper->GetSpecificationVersion("BogusSpecification", bIsSupported, nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetSpecificationVersion("BogusSpecification", bIsSupported, nMajor, nMinor, nMicro);
 		ASSERT_FALSE(bIsSupported);
 
-		wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/core/2015/02", bIsSupported, nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/core/2015/02", bIsSupported, nMajor, nMinor, nMicro);
 		ASSERT_TRUE(bIsSupported);
 		ASSERT_EQ(nMajor, 1);
 		ASSERT_EQ(nMinor, 2);
 		ASSERT_EQ(nMicro, 3);
 
-		wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/material/2015/02", bIsSupported, nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/material/2015/02", bIsSupported, nMajor, nMinor, nMicro);
 		ASSERT_TRUE(bIsSupported);
 		ASSERT_EQ(nMajor, 1);
 		ASSERT_EQ(nMinor, 1);
 		ASSERT_EQ(nMicro, 0);
 
-		wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/production/2015/06", bIsSupported, nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/production/2015/06", bIsSupported, nMajor, nMinor, nMicro);
 		ASSERT_TRUE(bIsSupported);
 		ASSERT_EQ(nMajor, 1);
 		ASSERT_EQ(nMinor, 1);
 		ASSERT_EQ(nMicro, 2);
 
-		wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02", bIsSupported, nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02", bIsSupported, nMajor, nMinor, nMicro);
 		ASSERT_TRUE(bIsSupported);
 		ASSERT_EQ(nMajor, 1);
 		ASSERT_EQ(nMinor, 1);
 		ASSERT_EQ(nMicro, 0);
 
-		wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/slice/2015/07", bIsSupported, nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/slice/2015/07", bIsSupported, nMajor, nMinor, nMicro);
 		ASSERT_TRUE(bIsSupported);
 		ASSERT_EQ(nMajor, 1);
 		ASSERT_EQ(nMinor, 0);
 		ASSERT_EQ(nMicro, 2);
 
-		wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/securecontent/2019/04", bIsSupported, nMajor, nMinor, nMicro);
+		Lib3MFTest::wrapper->GetSpecificationVersion("http://schemas.microsoft.com/3dmanufacturing/securecontent/2019/04", bIsSupported, nMajor, nMinor, nMicro);
 		ASSERT_TRUE(bIsSupported);
 		ASSERT_EQ(nMajor, 1);
 		ASSERT_EQ(nMinor, 0);
@@ -104,14 +110,14 @@ namespace Lib3MF
 
 	TEST(Wrapper, CreateModel)
 	{
-		auto model = wrapper->CreateModel();
+		auto model = Lib3MFTest::wrapper->CreateModel();
 	}
 
 	TEST(Wrapper, CheckError)
 	{
-		wrapper->CheckError(nullptr, 0);
+		Lib3MFTest::wrapper->CheckError(nullptr, 0);
 		try {
-			wrapper->CheckError(nullptr, 1);
+			Lib3MFTest::wrapper->CheckError(nullptr, 1);
 			ASSERT_TRUE(false);
 		}
 		catch (ELib3MFException &e) {
@@ -130,25 +136,25 @@ namespace Lib3MF
 		Lib3MF_single fR, fG, fB, fA;
 		Lib3MF_uint8 nR, nG, nB, nA;
 
-		wrapper->ColorToRGBA(c1, nR, nG, nB, nA);
+		Lib3MFTest::wrapper->ColorToRGBA(c1, nR, nG, nB, nA);
 		ASSERT_EQ(c1.m_Red, nR);
 		ASSERT_EQ(c1.m_Green, nG);
 		ASSERT_EQ(c1.m_Blue, nB);
 		ASSERT_EQ(c1.m_Alpha, nA);
 
-		wrapper->ColorToFloatRGBA(c1, fR, fG, fB, fA);
+		Lib3MFTest::wrapper->ColorToFloatRGBA(c1, fR, fG, fB, fA);
 		ASSERT_EQ(c1.m_Red, std::round(fR*255));
 		ASSERT_EQ(c1.m_Green, std::round(fG * 255));
 		ASSERT_EQ(c1.m_Blue, std::round(fB * 255));
 		ASSERT_EQ(c1.m_Alpha, std::round(fA * 255));
 
-		c2 = wrapper->RGBAToColor(nR, nG, nB, nA);
+		c2 = Lib3MFTest::wrapper->RGBAToColor(nR, nG, nB, nA);
 		ASSERT_EQ(c2.m_Red, nR);
 		ASSERT_EQ(c2.m_Green, nG);
 		ASSERT_EQ(c2.m_Blue, nB);
 		ASSERT_EQ(c2.m_Alpha, nA);
 
-		c2 = wrapper->FloatRGBAToColor(fR, fG, fB, fA);
+		c2 = Lib3MFTest::wrapper->FloatRGBAToColor(fR, fG, fB, fA);
 		ASSERT_EQ(c1.m_Red, c2.m_Red);
 		ASSERT_EQ(c1.m_Green, c2.m_Green);
 		ASSERT_EQ(c1.m_Blue, c2.m_Blue);

--- a/Tests/CPP_Bindings/Source/Writer.cpp
+++ b/Tests/CPP_Bindings/Source/Writer.cpp
@@ -35,7 +35,7 @@ UnitTest_Writer.cpp: Defines Unittests for the Writer classes
 
 namespace Lib3MF
 {
-	class Writer : public ::testing::Test {
+	class Writer : public Lib3MFTest {
 	protected:
 		sPosition pVertices[8];
 		sTriangle pTriangles[12];
@@ -87,13 +87,7 @@ namespace Lib3MF
 
 		static std::string InFolder;
 		static std::string OutFolder;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper Writer::wrapper;
 	std::string Writer::InFolder(sTestFilesPath + "/Writer/");
 	std::string Writer::OutFolder(sOutFilesPath + "/Writer/");
 	

--- a/Tests/CPP_Bindings/Source/v093.cpp
+++ b/Tests/CPP_Bindings/Source/v093.cpp
@@ -35,7 +35,7 @@ UnitTest_v093.cpp: Defines Unittests for the reading the 093-version of 3mf.
 
 namespace Lib3MF
 {
-	class ReaderV093 : public ::testing::Test {
+	class ReaderV093 : public Lib3MFTest {
 	protected:
 		virtual void SetUp() {
 			model = wrapper->CreateModel();
@@ -48,14 +48,8 @@ namespace Lib3MF
 	
 		PModel model;
 		PReader reader;
-
-		static void SetUpTestCase() {
-			wrapper = CWrapper::loadLibrary();
-		}
-		static PWrapper wrapper;
 	};
-	PWrapper ReaderV093::wrapper;
-
+	
 	TEST_F(ReaderV093, 3MFReadFromFile_Geometry)
 	{
 		reader->ReadFromFile(sTestFilesPath + "/v093/" + "Track_093.3mf");

--- a/Tests/codecoverage/run_codecoverage.sh
+++ b/Tests/codecoverage/run_codecoverage.sh
@@ -1,0 +1,15 @@
+cd build
+
+lcov --zerocounters  --directory .
+
+./Test_CPP_Bindings
+
+lcov --directory . --capture --output-file Test_CPP_Bindings.info
+
+TARGETDIR=`dirname \`pwd\``
+
+lcov --remove Test_CPP_Bindings.info -o Test_CPP_Bindings_filtered.info "$TARGETDIR/Tests/*" "$TARGETDIR/Source/Libraries/*" "$TARGETDIR/Include/Libraries/*" "/Applications/*"
+
+genhtml --output-directory ./codecoverage --title "lib3mf Test Coverage" --function-coverage --legend Test_CPP_Bindings_filtered.info   
+
+zip -r codecoverage.zip ./codecoverage/


### PR DESCRIPTION
Adds automatic test coverage calculation via lcov.
This is part of every build via github actions.
Results are reported as artifact of each github-action build and via: https://app.codecov.io/gh/3MFConsortium/lib3mf