### PR TITLE
Account for files not captured by the test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./build/Test_CPP_Bindings_filtered.info
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: false # optional (default = false)
           verbose: true # optional (default = false)
           
   build-windows-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./build/Test_CPP_Bindings_filtered.info
-          fail_ci_if_error: false # optional (default = false)
+          fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
           
   build-windows-release:

--- a/Tests/codecoverage/run_codecoverage.sh
+++ b/Tests/codecoverage/run_codecoverage.sh
@@ -1,10 +1,10 @@
 cd build
-
-lcov --zerocounters  --directory .
+lcov --no-external --capture --initial --directory . --output-file Test_CPP_Bindings_base.info
 
 ./Test_CPP_Bindings
 
-lcov --directory . --capture --output-file Test_CPP_Bindings.info
+lcov --directory . --capture --output-file Test_CPP_Bindings_run.info
+lcov --add-tracefile Test_CPP_Bindings_base.info --add-tracefile Test_CPP_Bindings_run.info --output-file Test_CPP_Bindings.info
 
 TARGETDIR=`dirname \`pwd\``
 

--- a/Tests/codecoverage/run_codecoverage.sh
+++ b/Tests/codecoverage/run_codecoverage.sh
@@ -1,5 +1,5 @@
 cd build
-lcov --no-external --capture --initial --directory . --output-file Test_CPP_Bindings_base.info
+lcov --capture --initial --directory . --output-file Test_CPP_Bindings_base.info
 
 ./Test_CPP_Bindings
 


### PR DESCRIPTION
Apparently, one needs to create a baseline for lcov first to capture source files with content that is not used _at all_.
( https://wiki.documentfoundation.org/Development/Lcov#Run_initial.2Fbaseline_lcov )

Having said that, it does not change the result. Probably, there are now unused files
