### PR TITLE
Enable clients with capability to set the encryption key of a resource data group

### DIFF
--- a/AutomaticComponentToolkit/lib3mf.xml
+++ b/AutomaticComponentToolkit/lib3mf.xml
@@ -1346,6 +1346,7 @@
 			<param name="Count" type="uint64" pass="return" description="The number of resource data available"/>
 		</method>
 		<method name="AddResourceDataGroup" description="Adds a resource data group into the keystore.">
+			<param name="ContentEncryptionKey" type="basicarray" class="uint8" pass="in" description="The (optional) encryption key that will be used to encrypt all resource datas in this group" />
 			<param name="ResourceDataGroup" type="class" class="ResourceDataGroup" pass="return" description="The resource data group instance"/>
 		</method>
 		<method name="GetResourceDataGroup" description="Gets a resource data group">

--- a/Include/API/lib3mf_keystore.hpp
+++ b/Include/API/lib3mf_keystore.hpp
@@ -95,7 +95,7 @@ namespace Lib3MF {
 
 			virtual IResourceDataGroup * GetResourceDataGroup(const Lib3MF_uint64 nResourceDataIndex) override;
 
-			virtual IResourceDataGroup * AddResourceDataGroup() override;
+			virtual IResourceDataGroup * AddResourceDataGroup(const Lib3MF_uint64 nContentEncryptionKeyBufferSize, const Lib3MF_uint8 * pContentEncryptionKeyBuffer) override;
 
 			virtual void RemoveResourceDataGroup(IResourceDataGroup * pTheResourceDataGroup) override;
 

--- a/Tests/CPP_Bindings/Source/EncryptionMethods.cpp
+++ b/Tests/CPP_Bindings/Source/EncryptionMethods.cpp
@@ -93,7 +93,7 @@ namespace Lib3MF {
 				ASSERT_NE(nullptr, meshObj);
 				auto keyStore = modelToCrpt->GetKeyStore();
 				auto consumer = keyStore->AddConsumer("LIB3MF#TEST", "contentKey", publicKey);
-				auto rdGroup = keyStore->AddResourceDataGroup();
+				auto rdGroup = keyStore->AddResourceDataGroup(ByteVector());
 				rdGroup->AddAccessRight(consumer.get(),
 					eWrappingAlgorithm::RSA_OAEP,
 					eMgfAlgorithm::MGF1_SHA1,
@@ -203,7 +203,7 @@ namespace Lib3MF {
 		Lib3MF::PConsumer consumer = keyStore->AddConsumer(consumerId, keyId, keyValue);
 
 		//add a resource data group
-		Lib3MF::PResourceDataGroup dataGroup = keyStore->AddResourceDataGroup();
+		Lib3MF::PResourceDataGroup dataGroup = keyStore->AddResourceDataGroup(ByteVector());
 
 		//establish consumer access to the datagroup
 		Lib3MF::PAccessRight accessRight = dataGroup->AddAccessRight(

--- a/Tests/CPP_Bindings/Source/SecureContent.cpp
+++ b/Tests/CPP_Bindings/Source/SecureContent.cpp
@@ -188,7 +188,7 @@ namespace Lib3MF {
 				ASSERT_NE(nullptr, meshObj);
 				auto keyStore = modelToCrpt->GetKeyStore();
 				auto consumer = keyStore->AddConsumer("LIB3MF#TEST", "contentKey", publicKey);
-				auto rdGroup = keyStore->AddResourceDataGroup();
+				auto rdGroup = keyStore->AddResourceDataGroup(std::vector<Lib3MF_uint8>());
 				rdGroup->AddAccessRight(consumer.get(),
 					eWrappingAlgorithm::RSA_OAEP,
 					eMgfAlgorithm::MGF1_SHA1,
@@ -296,7 +296,7 @@ namespace Lib3MF {
 		std::string path1 = "/3D/nonrootmodel1.model";
 		auto part1 = model->FindOrCreatePackagePart(path1);
 
-		auto dataGroup = keyStore->AddResourceDataGroup();
+		auto dataGroup = keyStore->AddResourceDataGroup(std::vector<Lib3MF_uint8>());
 
 		std::string dguuid = dataGroup->GetKeyUUID();
 		ASSERT_FALSE(dguuid.empty());
@@ -321,14 +321,14 @@ namespace Lib3MF {
 		std::string path1 = "/3D/nonrootmodel1.model";
 		auto part1 = model->FindOrCreatePackagePart(path1);
 
-		auto dataGroup1 = keyStore->AddResourceDataGroup();
+		auto dataGroup1 = keyStore->AddResourceDataGroup(std::vector<Lib3MF_uint8>());
 
 		keyStore->AddResourceData(dataGroup1.get(), part1.get(), Lib3MF::eEncryptionAlgorithm::AES256_GCM, Lib3MF::eCompression::Deflate, std::vector<Lib3MF_uint8>());
 
 		std::string path2 = "/3D/nonrootmodel2.model";
 		auto part2 = model->FindOrCreatePackagePart(path2);
 
-		auto dataGroup2 = keyStore->AddResourceDataGroup();
+		auto dataGroup2 = keyStore->AddResourceDataGroup(std::vector<Lib3MF_uint8>());
 
 		keyStore->AddResourceData(dataGroup2.get(), part2.get(), Lib3MF::eEncryptionAlgorithm::AES256_GCM, Lib3MF::eCompression::Deflate, std::vector<Lib3MF_uint8>());
 


### PR DESCRIPTION
Hi @martinweismann 

This hopes to close Issue #273 by enabling clients to specify an array with the content encryption key when creating a resource data group. This is still a WIP, I'd like to get your feedbacks on it first. If you think this is a good move, I'll improve testing.