### PR TITLE
Trianglesets fixing cmake, cbase constructor, writer and adding api to get triangleset ids

### DIFF
--- a/AutomaticComponentToolkit/lib3mf.xml
+++ b/AutomaticComponentToolkit/lib3mf.xml
@@ -581,6 +581,10 @@
 		<method name="SetTriangleList" description="Sets all triangles in the list, while clearing old values. Duplicates will be merged.">
 			<param name="TriangleIndices" type="basicarray" class="uint32" pass="in" description="Triangle indices to add. Every element MUST be between 0 and TriangleCount - 1."/>
 		</method>
+
+		<method name="GetTriangleList" description="Retrieves all the triangles in the TriangleSet">
+			<param name="TriangleIndices" type="basicarray" class="uint32" pass="out" description="retrieves the indices of the triangles in this TriangleSet"/>
+		</method>
 				
 		<method name="AddTriangleList" description="Adds multiple triangles in the list. Duplicates will be merged.">
 			<param name="TriangleIndices" type="basicarray" class="uint32" pass="in" description="Triangle indices to add. Every element MUST be between 0 and TriangleCount - 1."/>

--- a/Include/API/lib3mf_triangleset.hpp
+++ b/Include/API/lib3mf_triangleset.hpp
@@ -82,6 +82,8 @@ public:
 
 	void SetTriangleList(const Lib3MF_uint64 nTriangleIndicesBufferSize, const Lib3MF_uint32* pTriangleIndicesBuffer) override;
 
+	void GetTriangleList(Lib3MF_uint64 nTriangleIndicesBufferSize, Lib3MF_uint64 * pTriangleIndicesNeededCount, Lib3MF_uint32 * pTriangleIndicesBuffer) override;
+
 	void AddTriangleList(const Lib3MF_uint64 nTriangleIndicesBufferSize, const Lib3MF_uint32* pTriangleIndicesBuffer) override;
 
 	void Merge(ITriangleSet* pOtherTriangleSet, const bool bDeleteOther) override;

--- a/Source/API/lib3mf_triangleset.cpp
+++ b/Source/API/lib3mf_triangleset.cpp
@@ -100,6 +100,24 @@ void CTriangleSet::SetTriangleList(const Lib3MF_uint64 nTriangleIndicesBufferSiz
 	}
 }
 
+void CTriangleSet::GetTriangleList(Lib3MF_uint64 nTriangleIndicesBufferSize, Lib3MF_uint64 * pTriangleIndicesNeededCount, Lib3MF_uint32 * pTriangleIndicesBuffer)
+{
+	auto triangleIndicesSet = m_pTriangleSet->getTriangles();
+	Lib3MF_uint32 count = (Lib3MF_uint32)triangleIndicesSet.size();
+	if (pTriangleIndicesNeededCount)
+		*pTriangleIndicesNeededCount = count;
+
+	if (nTriangleIndicesBufferSize >= count && pTriangleIndicesBuffer)
+	{
+		Lib3MF_uint32* pIndex = pTriangleIndicesBuffer;
+		for (auto index : triangleIndicesSet)
+		{
+			*pIndex = index;
+			pIndex++;
+		}
+	}
+}
+
 void CTriangleSet::AddTriangleList(const Lib3MF_uint64 nTriangleIndicesBufferSize, const Lib3MF_uint32* pTriangleIndicesBuffer)
 {
 	if (pTriangleIndicesBuffer) {

--- a/Source/API/lib3mf_triangleset.cpp
+++ b/Source/API/lib3mf_triangleset.cpp
@@ -39,7 +39,7 @@ Abstract: This is a stub class definition of CMeshObject
 using namespace Lib3MF::Impl;
 
 CTriangleSet::CTriangleSet(NMR::PModelTriangleSet pTriangleSet, NMR::PModelMeshObject pMeshObject)
-	: CBase (), m_pTriangleSet (pTriangleSet), m_pMeshObject (pMeshObject)
+	: m_pTriangleSet (pTriangleSet), m_pMeshObject (pMeshObject)
 {
 	if (pTriangleSet.get() == nullptr)
 		throw ELib3MFInterfaceException(LIB3MF_ERROR_INVALIDPARAM);

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -72,6 +72,7 @@ Source/API/lib3mf_texture2d.cpp
 Source/API/lib3mf_texture2dgroup.cpp
 Source/API/lib3mf_texture2dgroupiterator.cpp
 Source/API/lib3mf_texture2diterator.cpp
+Source/API/lib3mf_triangleset.cpp
 Source/API/lib3mf_writer.cpp
 Source/API/lib3mf_utils.cpp
 Source/Common/3MF_ProgressMonitor.cpp
@@ -196,6 +197,9 @@ Source/Model/Reader/v100/NMR_ModelReaderNode100_Tex2DGroup.cpp
 Source/Model/Reader/v100/NMR_ModelReaderNode100_Texture2D.cpp
 Source/Model/Reader/v100/NMR_ModelReaderNode100_Triangle.cpp
 Source/Model/Reader/v100/NMR_ModelReaderNode100_Triangles.cpp
+Source/Model/Reader/v100/NMR_ModelReaderNode100_TriangleSet.cpp
+Source/Model/Reader/v100/NMR_ModelReaderNode100_TriangleSets.cpp
+Source/Model/Reader/v100/NMR_ModelReaderNode100_TriangleSetRef.cpp
 Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertex.cpp
 Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertices.cpp
 Source/Model/Reader/v093/NMR_ModelReaderNode093_Build.cpp

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -148,6 +148,7 @@ Source/Model/Classes/NMR_ModelTexture2D.cpp
 Source/Model/Classes/NMR_ModelTexture2DGroup.cpp
 Source/Model/Classes/NMR_ModelSlice.cpp
 Source/Model/Classes/NMR_ModelSliceStack.cpp
+Source/Model/Classes/NMR_ModelTriangleSet.cpp
 Source/Model/Classes/NMR_KeyStore.cpp
 Source/Model/Classes/NMR_KeyStoreConsumer.cpp
 Source/Model/Classes/NMR_KeyStoreAccessRight.cpp

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_TriangleSet.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_TriangleSet.cpp
@@ -61,12 +61,15 @@ namespace NMR {
 	void CModelReaderNode100_TriangleSet::OnAttribute(_In_z_ const nfChar * pAttributeName, _In_z_ const nfChar * pAttributeValue)
 	{
 		__NMRASSERT(pAttributeName);
-		__NMRASSERT(pAttributeValue);
+		__NMRASSERT(pAttributeValue); 
 		
-		
+		if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_TRIANGLESET_NAME) == 0) {
+            m_sName = pAttributeValue;
+		}
+		else if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_TRIANGLESET_IDENTIFIER) == 0) {
+			m_sIdentifier = pAttributeValue;
+		}
 	}
-
-
 
 	void CModelReaderNode100_TriangleSet::OnNSChildElement(_In_z_ const nfChar* pChildName, _In_z_ const nfChar* pNameSpace, _In_ CXmlReader* pXMLReader)
 	{
@@ -75,7 +78,7 @@ namespace NMR {
 		__NMRASSERT(pNameSpace);
 
 		if (strcmp(pNameSpace, XML_3MF_NAMESPACE_TRIANGLESETS) == 0) {
-			if (strcmp(pChildName, XML_3MF_ELEMENT_TRIANGLESET) == 0)
+			if (strcmp(pChildName, XML_3MF_ELEMENT_REF) == 0)
 			{
 				PModelReaderNode100_TriangleSetRef pXMLNode = std::make_shared<CModelReaderNode100_TriangleSetRef>(m_pWarnings);
 				pXMLNode->parseXML(pXMLReader);


### PR DESCRIPTION
I made the following fixes:

1. Fixed the cmakelists to add missing .cpp files
2. Fixed a vs2015 issue with a constructor for CBase class that wasn't defined
3. Fixed triangleset reader to look for the correct element for triangle indices

I also added an API to query the TriangleSet indices