### PR TITLE
arcz/indentation

### DIFF
--- a/Source/Model/Reader/NMR_ModelReaderNode.cpp
+++ b/Source/Model/Reader/NMR_ModelReaderNode.cpp
@@ -175,14 +175,14 @@ namespace NMR {
 				if (!pszNameSpaceURI)
 					throw CNMRException(NMR_ERROR_COULDNOTGETNAMESPACE);
 
-					if (nCount > 0) {
-						if (pszNameSpaceURI == nullptr) {
-							OnNSChildElement(pszLocalName, "", pXMLReader);
-						}
-						else {
-							OnNSChildElement(pszLocalName, pszNameSpaceURI, pXMLReader);
-						}
+				if (nCount > 0) {
+					if (pszNameSpaceURI == nullptr) {
+						OnNSChildElement(pszLocalName, "", pXMLReader);
 					}
+					else {
+						OnNSChildElement(pszLocalName, pszNameSpaceURI, pXMLReader);
+					}
+				}
 				break;
 
 			case XMLREADERNODETYPE_TEXT:


### PR DESCRIPTION
From https://github.com/arcz

Found with the compilation warning:
```
[143/260] Building CXX object CMakeFiles/lib3mf.dir/Source/Model/Reader/NMR_ModelReaderNode.cpp.o.cpp.oeamLattice1702_Ref.cpp.o.o                                
../Source/Model/Reader/NMR_ModelReaderNode.cpp: In member function 'void NMR::CModelReaderNode::parseContent(NMR::CXmlReader*)':                                 
../Source/Model/Reader/NMR_ModelReaderNode.cpp:175:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]                                     
  175 |     if (!pszNameSpaceURI)                                                                                                                                
      |     ^~                                                                                                                                                   
../Source/Model/Reader/NMR_ModelReaderNode.cpp:178:6: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'         
  178 |      if (nCount > 0) {                                                                                                                                   
      |      ^~   
```