### PR TITLE
Fix locale dependency when reading files (fixes #282).

### DIFF
--- a/Source/Common/NMR_StringUtils.cpp
+++ b/Source/Common/NMR_StringUtils.cpp
@@ -151,19 +151,23 @@ namespace NMR {
 	nfDouble fnStringToDouble(_In_z_ const nfChar * pszValue)
 	{
 		__NMRASSERT(pwszValue);
+
+		std::istringstream iss(pszValue);
+		iss.imbue(std::locale::classic());
+
 		nfDouble dResult = 0.0;
-
-		// Convert to double and make a input and range check!
-		nfChar * pEndPtr;
-
-		dResult = strtod(pszValue, &pEndPtr);
+		iss >> dResult;
 
 		// Check if any conversion happened
-		if ((pEndPtr == pszValue) || (!pEndPtr))
+		const bool fail = !iss;
+		if (iss.eof() && fail)
 			throw CNMRException(NMR_ERROR_EMPTYSTRINGTODOUBLECONVERSION);
 
-		if ((*pEndPtr != '\0') && (*pEndPtr != ' '))
-			throw CNMRException(NMR_ERROR_INVALIDSTRINGTODOUBLECONVERSION);
+		if (!iss.eof()) {
+			const char next = iss.get();
+			if (next != ' ')
+				throw CNMRException(NMR_ERROR_INVALIDSTRINGTODOUBLECONVERSION);
+		}
 
 		if ((dResult == HUGE_VAL) || (dResult == -HUGE_VAL))
 			throw CNMRException(NMR_ERROR_STRINGTODOUBLECONVERSIONOUTOFRANGE);

--- a/Source/Model/Reader/v093/NMR_ModelReaderNode093_Vertex.cpp
+++ b/Source/Model/Reader/v093/NMR_ModelReaderNode093_Vertex.cpp
@@ -82,7 +82,7 @@ namespace NMR {
 		__NMRASSERT(pAttributeValue);
 
 		if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_VERTEX_X) == 0) {
-			m_fX = strtof(pAttributeValue, nullptr);
+			m_fX = fnStringToFloat(pAttributeValue);
 			if (std::isnan (m_fX))
 				throw CNMRException(NMR_ERROR_INVALIDMODELCOORDINATES);
 			if (fabs (m_fX) > XML_3MF_MAXIMUMCOORDINATEVALUE)
@@ -91,7 +91,7 @@ namespace NMR {
 		}
 
 		if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_VERTEX_Y) == 0) {
-			m_fY = strtof(pAttributeValue, nullptr);
+			m_fY = fnStringToFloat(pAttributeValue);
 			if (std::isnan (m_fY))
 				throw CNMRException(NMR_ERROR_INVALIDMODELCOORDINATES);
 			if (fabs(m_fY) > XML_3MF_MAXIMUMCOORDINATEVALUE)
@@ -100,7 +100,7 @@ namespace NMR {
 		}
 
 		if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_VERTEX_Z) == 0) {
-			m_fZ = strtof(pAttributeValue, nullptr);
+			m_fZ = fnStringToFloat(pAttributeValue);
 			if (std::isnan (m_fZ))
 				throw CNMRException(NMR_ERROR_INVALIDMODELCOORDINATES);
 			if (fabs(m_fZ) > XML_3MF_MAXIMUMCOORDINATEVALUE)

--- a/Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertex.cpp
+++ b/Source/Model/Reader/v100/NMR_ModelReaderNode100_Vertex.cpp
@@ -82,7 +82,7 @@ namespace NMR {
 		__NMRASSERT(pAttributeValue);
 
 		if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_VERTEX_X) == 0) {
-			m_fX = strtof(pAttributeValue, nullptr);
+			m_fX = fnStringToFloat(pAttributeValue);
 			if (std::isnan (m_fX))
 				throw CNMRException(NMR_ERROR_INVALIDMODELCOORDINATES);
 			if (fabs (m_fX) > XML_3MF_MAXIMUMCOORDINATEVALUE)
@@ -90,7 +90,7 @@ namespace NMR {
 			m_bHasX = true;
 		}
 		else if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_VERTEX_Y) == 0) {
-			m_fY = strtof(pAttributeValue, nullptr);
+			m_fY = fnStringToFloat(pAttributeValue);
 			if (std::isnan (m_fY))
 				throw CNMRException(NMR_ERROR_INVALIDMODELCOORDINATES);
 			if (fabs(m_fY) > XML_3MF_MAXIMUMCOORDINATEVALUE)
@@ -98,7 +98,7 @@ namespace NMR {
 			m_bHasY = true;
 		}
 		else if (strcmp(pAttributeName, XML_3MF_ATTRIBUTE_VERTEX_Z) == 0) {
-			m_fZ = strtof(pAttributeValue, nullptr);
+			m_fZ = fnStringToFloat(pAttributeValue);
 			if (std::isnan (m_fZ))
 				throw CNMRException(NMR_ERROR_INVALIDMODELCOORDINATES);
 			if (fabs(m_fZ) > XML_3MF_MAXIMUMCOORDINATEVALUE)


### PR DESCRIPTION
This replaces the use of `strtod()` and `strtof()` which are both dependent on the system locale setting with stringstream input which can be forced to a fixed locale without changing global settings.

This issue starts to break OpenSCAD installations as some Linux distributions have moved to `lib3mf` v2.2.0. At this point, I'm aware of Arch and Fedora shipping this version and the Flatpak build of OpenSCAD also uses the last `lib3mf` release.

This fixes both the issue of not being able to open the file at all due to failure reading the `<build><item>` transformation matrix as described in https://github.com/3MFConsortium/lib3mf/issues/282#issuecomment-1029069098 and https://github.com/openscad/openscad/issues/4723, and the truncation of vertex information to integers shown in the issue description of #282 and https://github.com/openscad/openscad/issues/4204.