### PR TITLE
Update CMakeLists.txt to ignore cmake_osx_architecture in TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,10 +237,6 @@ option(LIB3MF_TESTS "Switch whether the tests of lib3mf should be build" ON)
 message("LIB3MF_TESTS ... " ${LIB3MF_TESTS})
 
 if(LIB3MF_TESTS)
-  if(APPLE)
-    # libressl only compiles on arm64
-    SET(CMAKE_OSX_ARCHITECTURES "x86_64")
-  endif()
   enable_testing()
   add_subdirectory(Tests)
 endif()


### PR DESCRIPTION
Previously libreSSL could not be built on arm64 machines, so there was a flag to build the test only for intel x86_64 machines. 

After updating the libreSSL library, it might not be the case anymore. So removing the CMAKE_OSX_ARCHITECTURE flag.