### PR TITLE
Issue 363: changing double factor from int to long long

### DIFF
--- a/Include/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.h
+++ b/Include/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.h
@@ -84,7 +84,7 @@ namespace NMR {
 		nfUint32 m_nBallRefBufferPos;
 	private:
 		const int m_nPosAfterDecPoint;
-		const int m_nPutDoubleFactor;
+		const nfInt64 m_nPutDoubleFactor;
 		__NMR_INLINE void putFloat(_In_ const nfFloat fValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos);
 		__NMR_INLINE void putDouble(_In_ const nfDouble dValue, _In_ std::array<nfChar, MODELWRITERMESH100_LINEBUFFERSIZE> & line, _In_ nfUint32 & nBufferPos);
 

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
@@ -79,7 +79,7 @@ namespace NMR {
 		putBallRefString(MODELWRITERMESH100_BEAMLATTICE_BALLREFLINESTART);
 	}
 
-	bool stringRepresentationsDiffer(double a, double b, double putFactor) {
+	bool stringRepresentationsDiffer(double a, double b, nfInt64 putFactor) {
 		return  fabs(a - b) * putFactor > 0.1;
 	}
 

--- a/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
+++ b/Source/Model/Writer/v100/NMR_ModelWriterNode100_Mesh.cpp
@@ -52,7 +52,7 @@ namespace NMR {
 
 	CModelWriterNode100_Mesh::CModelWriterNode100_Mesh(_In_ CModelMeshObject * pModelMeshObject, _In_ CXmlWriter * pXMLWriter, _In_ PProgressMonitor pProgressMonitor,
 		_In_ PMeshInformation_PropertyIndexMapping pPropertyIndexMapping, _In_ int nPosAfterDecPoint, _In_ nfBool bWriteMaterialExtension, _In_ nfBool bWriteBeamLatticeExtension)
-		:CModelWriterNode_ModelBase(pModelMeshObject->getModel(), pXMLWriter, pProgressMonitor), m_nPosAfterDecPoint(nPosAfterDecPoint), m_nPutDoubleFactor((int)(pow(10, CModelWriterNode100_Mesh::m_nPosAfterDecPoint)))
+		:CModelWriterNode_ModelBase(pModelMeshObject->getModel(), pXMLWriter, pProgressMonitor), m_nPosAfterDecPoint(nPosAfterDecPoint), m_nPutDoubleFactor((nfInt64)(pow(10, CModelWriterNode100_Mesh::m_nPosAfterDecPoint)))
 	{
 		__NMRASSERT(pModelMeshObject != nullptr);
 		if (!pPropertyIndexMapping.get())


### PR DESCRIPTION
SetDecimalPrecision not working for values above 9 decimal places.

I notice in the [PR ](https://github.com/3MFConsortium/lib3mf/pull/169/files)that created this API that we cast a very large number to an int, when it should probably be a long long (m_nPutDoubleFactor). I stongly suspect this will fix the issue.