### PR TITLE
Include a additional entry to build.yml to pack source code + submodules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -521,7 +521,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: lib3mf-${{ env.LIB3MF_VERSION }}-source-with-submodules.zip
+          name: lib3mf-${{ env.LIB3MF_VERSION }}-source-with-submodules
           path: lib3mf-${{ env.LIB3MF_VERSION }}-source-with-submodules
 
 


### PR DESCRIPTION
This artifact would be useful for people who just want to build the code with a zip file without downloading anything online. Its especially useful for VCPKG.