### PR TITLE
ISSUE-284: fix CSharp crash when passing struct

### DIFF
--- a/Autogenerated/Bindings/CSharp/Lib3MF.cs
+++ b/Autogenerated/Bindings/CSharp/Lib3MF.cs
@@ -757,10 +757,10 @@ namespace Lib3MF {
 			public unsafe extern static Int32 MeshObject_GetVertex (IntPtr Handle, UInt32 AIndex, out InternalPosition ACoordinates);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_setvertex", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 MeshObject_SetVertex (IntPtr Handle, UInt32 AIndex, InternalPosition ACoordinates);
+			public unsafe extern static Int32 MeshObject_SetVertex (IntPtr Handle, UInt32 AIndex, ref InternalPosition ACoordinates);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_addvertex", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 MeshObject_AddVertex (IntPtr Handle, InternalPosition ACoordinates, out UInt32 ANewIndex);
+			public unsafe extern static Int32 MeshObject_AddVertex (IntPtr Handle, ref InternalPosition ACoordinates, out UInt32 ANewIndex);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_getvertices", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 MeshObject_GetVertices (IntPtr Handle, UInt64 sizeVertices, out UInt64 neededVertices, IntPtr dataVertices);
@@ -769,10 +769,10 @@ namespace Lib3MF {
 			public unsafe extern static Int32 MeshObject_GetTriangle (IntPtr Handle, UInt32 AIndex, out InternalTriangle AIndices);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_settriangle", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 MeshObject_SetTriangle (IntPtr Handle, UInt32 AIndex, InternalTriangle AIndices);
+			public unsafe extern static Int32 MeshObject_SetTriangle (IntPtr Handle, UInt32 AIndex, ref InternalTriangle AIndices);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_addtriangle", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 MeshObject_AddTriangle (IntPtr Handle, InternalTriangle AIndices, out UInt32 ANewIndex);
+			public unsafe extern static Int32 MeshObject_AddTriangle (IntPtr Handle, ref InternalTriangle AIndices, out UInt32 ANewIndex);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_gettriangleindices", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 MeshObject_GetTriangleIndices (IntPtr Handle, UInt64 sizeIndices, out UInt64 neededIndices, IntPtr dataIndices);
@@ -784,7 +784,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 MeshObject_GetObjectLevelProperty (IntPtr Handle, out UInt32 AUniqueResourceID, out UInt32 APropertyID, out Byte AHasObjectLevelProperty);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_settriangleproperties", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 MeshObject_SetTriangleProperties (IntPtr Handle, UInt32 AIndex, InternalTriangleProperties AProperties);
+			public unsafe extern static Int32 MeshObject_SetTriangleProperties (IntPtr Handle, UInt32 AIndex, ref InternalTriangleProperties AProperties);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_meshobject_gettriangleproperties", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 MeshObject_GetTriangleProperties (IntPtr Handle, UInt32 AIndex, out InternalTriangleProperties AProperty);
@@ -838,7 +838,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 LevelSet_GetTransform (IntPtr Handle, out InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_levelset_settransform", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 LevelSet_SetTransform (IntPtr Handle, InternalTransform ATransform);
+			public unsafe extern static Int32 LevelSet_SetTransform (IntPtr Handle, ref InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_levelset_getchannelname", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 LevelSet_GetChannelName (IntPtr Handle, UInt32 sizeChannelName, out UInt32 neededChannelName, IntPtr dataChannelName);
@@ -907,10 +907,10 @@ namespace Lib3MF {
 			public unsafe extern static Int32 BeamLattice_GetBeam (IntPtr Handle, UInt32 AIndex, out InternalBeam ABeamInfo);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_beamlattice_addbeam", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 BeamLattice_AddBeam (IntPtr Handle, InternalBeam ABeamInfo, out UInt32 AIndex);
+			public unsafe extern static Int32 BeamLattice_AddBeam (IntPtr Handle, ref InternalBeam ABeamInfo, out UInt32 AIndex);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_beamlattice_setbeam", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 BeamLattice_SetBeam (IntPtr Handle, UInt32 AIndex, InternalBeam ABeamInfo);
+			public unsafe extern static Int32 BeamLattice_SetBeam (IntPtr Handle, UInt32 AIndex, ref InternalBeam ABeamInfo);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_beamlattice_setbeams", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 BeamLattice_SetBeams (IntPtr Handle, UInt64 sizeBeamInfo, IntPtr dataBeamInfo);
@@ -925,10 +925,10 @@ namespace Lib3MF {
 			public unsafe extern static Int32 BeamLattice_GetBall (IntPtr Handle, UInt32 AIndex, out InternalBall ABallInfo);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_beamlattice_addball", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 BeamLattice_AddBall (IntPtr Handle, InternalBall ABallInfo, out UInt32 AIndex);
+			public unsafe extern static Int32 BeamLattice_AddBall (IntPtr Handle, ref InternalBall ABallInfo, out UInt32 AIndex);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_beamlattice_setball", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 BeamLattice_SetBall (IntPtr Handle, UInt32 AIndex, InternalBall ABallInfo);
+			public unsafe extern static Int32 BeamLattice_SetBall (IntPtr Handle, UInt32 AIndex, ref InternalBall ABallInfo);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_beamlattice_setballs", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 BeamLattice_SetBalls (IntPtr Handle, UInt64 sizeBallInfo, IntPtr dataBallInfo);
@@ -955,7 +955,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 FunctionReference_GetTransform (IntPtr Handle, out InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_functionreference_settransform", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 FunctionReference_SetTransform (IntPtr Handle, InternalTransform ATransform);
+			public unsafe extern static Int32 FunctionReference_SetTransform (IntPtr Handle, ref InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_functionreference_getchannelname", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 FunctionReference_GetChannelName (IntPtr Handle, UInt32 sizeChannelName, out UInt32 neededChannelName, IntPtr dataChannelName);
@@ -988,7 +988,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 VolumeDataComposite_GetMaterialMapping (IntPtr Handle, UInt32 AIndex, out IntPtr ATheMaterialMapping);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_volumedatacomposite_addmaterialmapping", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 VolumeDataComposite_AddMaterialMapping (IntPtr Handle, InternalTransform ATransform, out IntPtr ATheMaterialMapping);
+			public unsafe extern static Int32 VolumeDataComposite_AddMaterialMapping (IntPtr Handle, ref InternalTransform ATransform, out IntPtr ATheMaterialMapping);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_volumedatacomposite_removematerialmapping", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 VolumeDataComposite_RemoveMaterialMapping (IntPtr Handle, UInt32 AIndex);
@@ -1051,10 +1051,10 @@ namespace Lib3MF {
 			public unsafe extern static Int32 Component_GetTransform (IntPtr Handle, out InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_component_settransform", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 Component_SetTransform (IntPtr Handle, InternalTransform ATransform);
+			public unsafe extern static Int32 Component_SetTransform (IntPtr Handle, ref InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_componentsobject_addcomponent", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 ComponentsObject_AddComponent (IntPtr Handle, IntPtr AObjectResource, InternalTransform ATransform, out IntPtr AComponentInstance);
+			public unsafe extern static Int32 ComponentsObject_AddComponent (IntPtr Handle, IntPtr AObjectResource, ref InternalTransform ATransform, out IntPtr AComponentInstance);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_componentsobject_getcomponent", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 ComponentsObject_GetComponent (IntPtr Handle, UInt32 AIndex, out IntPtr AComponentInstance);
@@ -1099,7 +1099,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 BaseMaterialGroup_GetAllPropertyIDs (IntPtr Handle, UInt64 sizePropertyIDs, out UInt64 neededPropertyIDs, IntPtr dataPropertyIDs);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_basematerialgroup_addmaterial", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 BaseMaterialGroup_AddMaterial (IntPtr Handle, byte[] AName, InternalColor ADisplayColor, out UInt32 APropertyID);
+			public unsafe extern static Int32 BaseMaterialGroup_AddMaterial (IntPtr Handle, byte[] AName, ref InternalColor ADisplayColor, out UInt32 APropertyID);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_basematerialgroup_removematerial", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 BaseMaterialGroup_RemoveMaterial (IntPtr Handle, UInt32 APropertyID);
@@ -1111,7 +1111,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 BaseMaterialGroup_SetName (IntPtr Handle, UInt32 APropertyID, byte[] AName);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_basematerialgroup_setdisplaycolor", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 BaseMaterialGroup_SetDisplayColor (IntPtr Handle, UInt32 APropertyID, InternalColor ATheColor);
+			public unsafe extern static Int32 BaseMaterialGroup_SetDisplayColor (IntPtr Handle, UInt32 APropertyID, ref InternalColor ATheColor);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_basematerialgroup_getdisplaycolor", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 BaseMaterialGroup_GetDisplayColor (IntPtr Handle, UInt32 APropertyID, out InternalColor ATheColor);
@@ -1123,13 +1123,13 @@ namespace Lib3MF {
 			public unsafe extern static Int32 ColorGroup_GetAllPropertyIDs (IntPtr Handle, UInt64 sizePropertyIDs, out UInt64 neededPropertyIDs, IntPtr dataPropertyIDs);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_colorgroup_addcolor", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 ColorGroup_AddColor (IntPtr Handle, InternalColor ATheColor, out UInt32 APropertyID);
+			public unsafe extern static Int32 ColorGroup_AddColor (IntPtr Handle, ref InternalColor ATheColor, out UInt32 APropertyID);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_colorgroup_removecolor", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 ColorGroup_RemoveColor (IntPtr Handle, UInt32 APropertyID);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_colorgroup_setcolor", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 ColorGroup_SetColor (IntPtr Handle, UInt32 APropertyID, InternalColor ATheColor);
+			public unsafe extern static Int32 ColorGroup_SetColor (IntPtr Handle, UInt32 APropertyID, ref InternalColor ATheColor);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_colorgroup_getcolor", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 ColorGroup_GetColor (IntPtr Handle, UInt32 APropertyID, out InternalColor ATheColor);
@@ -1141,7 +1141,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 Texture2DGroup_GetAllPropertyIDs (IntPtr Handle, UInt64 sizePropertyIDs, out UInt64 neededPropertyIDs, IntPtr dataPropertyIDs);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_texture2dgroup_addtex2coord", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 Texture2DGroup_AddTex2Coord (IntPtr Handle, InternalTex2Coord AUVCoordinate, out UInt32 APropertyID);
+			public unsafe extern static Int32 Texture2DGroup_AddTex2Coord (IntPtr Handle, ref InternalTex2Coord AUVCoordinate, out UInt32 APropertyID);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_texture2dgroup_gettex2coord", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 Texture2DGroup_GetTex2Coord (IntPtr Handle, UInt32 APropertyID, out InternalTex2Coord AUVCoordinate);
@@ -1192,7 +1192,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 MultiPropertyGroup_GetLayerCount (IntPtr Handle, out UInt32 ACount);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_multipropertygroup_addlayer", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 MultiPropertyGroup_AddLayer (IntPtr Handle, InternalMultiPropertyLayer ATheLayer, out UInt32 ALayerIndex);
+			public unsafe extern static Int32 MultiPropertyGroup_AddLayer (IntPtr Handle, ref InternalMultiPropertyLayer ATheLayer, out UInt32 ALayerIndex);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_multipropertygroup_getlayer", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 MultiPropertyGroup_GetLayer (IntPtr Handle, UInt32 ALayerIndex, out InternalMultiPropertyLayer ATheLayer);
@@ -1522,7 +1522,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 ConstantNode_GetOutputValue (IntPtr Handle, out IntPtr AValue);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_constvecnode_setvector", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 ConstVecNode_SetVector (IntPtr Handle, InternalVector AValue);
+			public unsafe extern static Int32 ConstVecNode_SetVector (IntPtr Handle, ref InternalVector AValue);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_constvecnode_getvector", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 ConstVecNode_GetVector (IntPtr Handle, out InternalVector AValue);
@@ -1531,7 +1531,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 ConstVecNode_GetOutputVector (IntPtr Handle, out IntPtr AVector);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_constmatnode_setmatrix", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 ConstMatNode_SetMatrix (IntPtr Handle, InternalMatrix4x4 AValue);
+			public unsafe extern static Int32 ConstMatNode_SetMatrix (IntPtr Handle, ref InternalMatrix4x4 AValue);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_constmatnode_getmatrix", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 ConstMatNode_GetMatrix (IntPtr Handle, out InternalMatrix4x4 AValue);
@@ -1816,7 +1816,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 BuildItem_GetObjectTransform (IntPtr Handle, out InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_builditem_setobjecttransform", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 BuildItem_SetObjectTransform (IntPtr Handle, InternalTransform ATransform);
+			public unsafe extern static Int32 BuildItem_SetObjectTransform (IntPtr Handle, ref InternalTransform ATransform);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_builditem_getpartnumber", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 BuildItem_GetPartNumber (IntPtr Handle, UInt32 sizePartNumber, out UInt32 neededPartNumber, IntPtr dataPartNumber);
@@ -2170,7 +2170,7 @@ namespace Lib3MF {
 			public unsafe extern static Int32 Model_GetImageStackByID (IntPtr Handle, UInt32 AUniqueResourceID, out IntPtr AImageStackInstance);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_model_addbuilditem", CallingConvention=CallingConvention.Cdecl)]
-			public unsafe extern static Int32 Model_AddBuildItem (IntPtr Handle, IntPtr AObject, InternalTransform ATransform, out IntPtr ABuildItemInstance);
+			public unsafe extern static Int32 Model_AddBuildItem (IntPtr Handle, IntPtr AObject, ref InternalTransform ATransform, out IntPtr ABuildItemInstance);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_model_removebuilditem", CallingConvention=CallingConvention.Cdecl)]
 			public unsafe extern static Int32 Model_RemoveBuildItem (IntPtr Handle, IntPtr ABuildItemInstance);
@@ -2278,10 +2278,10 @@ namespace Lib3MF {
 			public extern static Int32 FloatRGBAToColor (Single ARed, Single AGreen, Single ABlue, Single AAlpha, out InternalColor ATheColor);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_colortorgba", CharSet = CharSet.Ansi, CallingConvention=CallingConvention.Cdecl)]
-			public extern static Int32 ColorToRGBA (InternalColor ATheColor, out Byte ARed, out Byte AGreen, out Byte ABlue, out Byte AAlpha);
+			public extern static Int32 ColorToRGBA (ref InternalColor ATheColor, out Byte ARed, out Byte AGreen, out Byte ABlue, out Byte AAlpha);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_colortofloatrgba", CharSet = CharSet.Ansi, CallingConvention=CallingConvention.Cdecl)]
-			public extern static Int32 ColorToFloatRGBA (InternalColor ATheColor, out Single ARed, out Single AGreen, out Single ABlue, out Single AAlpha);
+			public extern static Int32 ColorToFloatRGBA (ref InternalColor ATheColor, out Single ARed, out Single AGreen, out Single ABlue, out Single AAlpha);
 
 			[DllImport("lib3mf.dll", EntryPoint = "lib3mf_getidentitytransform", CharSet = CharSet.Ansi, CallingConvention=CallingConvention.Cdecl)]
 			public extern static Int32 GetIdentityTransform (out InternalTransform ATransform);
@@ -3912,7 +3912,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalPosition intCoordinates = Internal.Lib3MFWrapper.convertStructToInternal_Position (ACoordinates);
 
-			CheckError(Internal.Lib3MFWrapper.MeshObject_SetVertex (Handle, AIndex, intCoordinates));
+			CheckError(Internal.Lib3MFWrapper.MeshObject_SetVertex (Handle, AIndex, ref intCoordinates));
 		}
 
 		public UInt32 AddVertex (sPosition ACoordinates)
@@ -3920,7 +3920,7 @@ namespace Lib3MF {
 			Internal.InternalPosition intCoordinates = Internal.Lib3MFWrapper.convertStructToInternal_Position (ACoordinates);
 			UInt32 resultNewIndex = 0;
 
-			CheckError(Internal.Lib3MFWrapper.MeshObject_AddVertex (Handle, intCoordinates, out resultNewIndex));
+			CheckError(Internal.Lib3MFWrapper.MeshObject_AddVertex (Handle, ref intCoordinates, out resultNewIndex));
 			return resultNewIndex;
 		}
 
@@ -3952,7 +3952,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalTriangle intIndices = Internal.Lib3MFWrapper.convertStructToInternal_Triangle (AIndices);
 
-			CheckError(Internal.Lib3MFWrapper.MeshObject_SetTriangle (Handle, AIndex, intIndices));
+			CheckError(Internal.Lib3MFWrapper.MeshObject_SetTriangle (Handle, AIndex, ref intIndices));
 		}
 
 		public UInt32 AddTriangle (sTriangle AIndices)
@@ -3960,7 +3960,7 @@ namespace Lib3MF {
 			Internal.InternalTriangle intIndices = Internal.Lib3MFWrapper.convertStructToInternal_Triangle (AIndices);
 			UInt32 resultNewIndex = 0;
 
-			CheckError(Internal.Lib3MFWrapper.MeshObject_AddTriangle (Handle, intIndices, out resultNewIndex));
+			CheckError(Internal.Lib3MFWrapper.MeshObject_AddTriangle (Handle, ref intIndices, out resultNewIndex));
 			return resultNewIndex;
 		}
 
@@ -3998,7 +3998,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalTriangleProperties intProperties = Internal.Lib3MFWrapper.convertStructToInternal_TriangleProperties (AProperties);
 
-			CheckError(Internal.Lib3MFWrapper.MeshObject_SetTriangleProperties (Handle, AIndex, intProperties));
+			CheckError(Internal.Lib3MFWrapper.MeshObject_SetTriangleProperties (Handle, AIndex, ref intProperties));
 		}
 
 		public void GetTriangleProperties (UInt32 AIndex, out sTriangleProperties AProperty)
@@ -4172,7 +4172,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalTransform intTransform = Internal.Lib3MFWrapper.convertStructToInternal_Transform (ATransform);
 
-			CheckError(Internal.Lib3MFWrapper.LevelSet_SetTransform (Handle, intTransform));
+			CheckError(Internal.Lib3MFWrapper.LevelSet_SetTransform (Handle, ref intTransform));
 		}
 
 		public String GetChannelName ()
@@ -4359,7 +4359,7 @@ namespace Lib3MF {
 			Internal.InternalBeam intBeamInfo = Internal.Lib3MFWrapper.convertStructToInternal_Beam (ABeamInfo);
 			UInt32 resultIndex = 0;
 
-			CheckError(Internal.Lib3MFWrapper.BeamLattice_AddBeam (Handle, intBeamInfo, out resultIndex));
+			CheckError(Internal.Lib3MFWrapper.BeamLattice_AddBeam (Handle, ref intBeamInfo, out resultIndex));
 			return resultIndex;
 		}
 
@@ -4367,7 +4367,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalBeam intBeamInfo = Internal.Lib3MFWrapper.convertStructToInternal_Beam (ABeamInfo);
 
-			CheckError(Internal.Lib3MFWrapper.BeamLattice_SetBeam (Handle, AIndex, intBeamInfo));
+			CheckError(Internal.Lib3MFWrapper.BeamLattice_SetBeam (Handle, AIndex, ref intBeamInfo));
 		}
 
 		public void SetBeams (sBeam[] ABeamInfo)
@@ -4418,7 +4418,7 @@ namespace Lib3MF {
 			Internal.InternalBall intBallInfo = Internal.Lib3MFWrapper.convertStructToInternal_Ball (ABallInfo);
 			UInt32 resultIndex = 0;
 
-			CheckError(Internal.Lib3MFWrapper.BeamLattice_AddBall (Handle, intBallInfo, out resultIndex));
+			CheckError(Internal.Lib3MFWrapper.BeamLattice_AddBall (Handle, ref intBallInfo, out resultIndex));
 			return resultIndex;
 		}
 
@@ -4426,7 +4426,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalBall intBallInfo = Internal.Lib3MFWrapper.convertStructToInternal_Ball (ABallInfo);
 
-			CheckError(Internal.Lib3MFWrapper.BeamLattice_SetBall (Handle, AIndex, intBallInfo));
+			CheckError(Internal.Lib3MFWrapper.BeamLattice_SetBall (Handle, AIndex, ref intBallInfo));
 		}
 
 		public void SetBalls (sBall[] ABallInfo)
@@ -4514,7 +4514,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalTransform intTransform = Internal.Lib3MFWrapper.convertStructToInternal_Transform (ATransform);
 
-			CheckError(Internal.Lib3MFWrapper.FunctionReference_SetTransform (Handle, intTransform));
+			CheckError(Internal.Lib3MFWrapper.FunctionReference_SetTransform (Handle, ref intTransform));
 		}
 
 		public String GetChannelName ()
@@ -4628,7 +4628,7 @@ namespace Lib3MF {
 			Internal.InternalTransform intTransform = Internal.Lib3MFWrapper.convertStructToInternal_Transform (ATransform);
 			IntPtr newTheMaterialMapping = IntPtr.Zero;
 
-			CheckError(Internal.Lib3MFWrapper.VolumeDataComposite_AddMaterialMapping (Handle, intTransform, out newTheMaterialMapping));
+			CheckError(Internal.Lib3MFWrapper.VolumeDataComposite_AddMaterialMapping (Handle, ref intTransform, out newTheMaterialMapping));
 			return Internal.Lib3MFWrapper.PolymorphicFactory<CMaterialMapping>(newTheMaterialMapping);
 		}
 
@@ -4830,7 +4830,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalTransform intTransform = Internal.Lib3MFWrapper.convertStructToInternal_Transform (ATransform);
 
-			CheckError(Internal.Lib3MFWrapper.Component_SetTransform (Handle, intTransform));
+			CheckError(Internal.Lib3MFWrapper.Component_SetTransform (Handle, ref intTransform));
 		}
 
 	}
@@ -4849,7 +4849,7 @@ namespace Lib3MF {
 			Internal.InternalTransform intTransform = Internal.Lib3MFWrapper.convertStructToInternal_Transform (ATransform);
 			IntPtr newComponentInstance = IntPtr.Zero;
 
-			CheckError(Internal.Lib3MFWrapper.ComponentsObject_AddComponent (Handle, AObjectResourceHandle, intTransform, out newComponentInstance));
+			CheckError(Internal.Lib3MFWrapper.ComponentsObject_AddComponent (Handle, AObjectResourceHandle, ref intTransform, out newComponentInstance));
 			return Internal.Lib3MFWrapper.PolymorphicFactory<CComponent>(newComponentInstance);
 		}
 
@@ -5012,7 +5012,7 @@ namespace Lib3MF {
 			Internal.InternalColor intDisplayColor = Internal.Lib3MFWrapper.convertStructToInternal_Color (ADisplayColor);
 			UInt32 resultPropertyID = 0;
 
-			CheckError(Internal.Lib3MFWrapper.BaseMaterialGroup_AddMaterial (Handle, byteName, intDisplayColor, out resultPropertyID));
+			CheckError(Internal.Lib3MFWrapper.BaseMaterialGroup_AddMaterial (Handle, byteName, ref intDisplayColor, out resultPropertyID));
 			return resultPropertyID;
 		}
 
@@ -5047,7 +5047,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalColor intTheColor = Internal.Lib3MFWrapper.convertStructToInternal_Color (ATheColor);
 
-			CheckError(Internal.Lib3MFWrapper.BaseMaterialGroup_SetDisplayColor (Handle, APropertyID, intTheColor));
+			CheckError(Internal.Lib3MFWrapper.BaseMaterialGroup_SetDisplayColor (Handle, APropertyID, ref intTheColor));
 		}
 
 		public sColor GetDisplayColor (UInt32 APropertyID)
@@ -5092,7 +5092,7 @@ namespace Lib3MF {
 			Internal.InternalColor intTheColor = Internal.Lib3MFWrapper.convertStructToInternal_Color (ATheColor);
 			UInt32 resultPropertyID = 0;
 
-			CheckError(Internal.Lib3MFWrapper.ColorGroup_AddColor (Handle, intTheColor, out resultPropertyID));
+			CheckError(Internal.Lib3MFWrapper.ColorGroup_AddColor (Handle, ref intTheColor, out resultPropertyID));
 			return resultPropertyID;
 		}
 
@@ -5106,7 +5106,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalColor intTheColor = Internal.Lib3MFWrapper.convertStructToInternal_Color (ATheColor);
 
-			CheckError(Internal.Lib3MFWrapper.ColorGroup_SetColor (Handle, APropertyID, intTheColor));
+			CheckError(Internal.Lib3MFWrapper.ColorGroup_SetColor (Handle, APropertyID, ref intTheColor));
 		}
 
 		public sColor GetColor (UInt32 APropertyID)
@@ -5151,7 +5151,7 @@ namespace Lib3MF {
 			Internal.InternalTex2Coord intUVCoordinate = Internal.Lib3MFWrapper.convertStructToInternal_Tex2Coord (AUVCoordinate);
 			UInt32 resultPropertyID = 0;
 
-			CheckError(Internal.Lib3MFWrapper.Texture2DGroup_AddTex2Coord (Handle, intUVCoordinate, out resultPropertyID));
+			CheckError(Internal.Lib3MFWrapper.Texture2DGroup_AddTex2Coord (Handle, ref intUVCoordinate, out resultPropertyID));
 			return resultPropertyID;
 		}
 
@@ -5328,7 +5328,7 @@ namespace Lib3MF {
 			Internal.InternalMultiPropertyLayer intTheLayer = Internal.Lib3MFWrapper.convertStructToInternal_MultiPropertyLayer (ATheLayer);
 			UInt32 resultLayerIndex = 0;
 
-			CheckError(Internal.Lib3MFWrapper.MultiPropertyGroup_AddLayer (Handle, intTheLayer, out resultLayerIndex));
+			CheckError(Internal.Lib3MFWrapper.MultiPropertyGroup_AddLayer (Handle, ref intTheLayer, out resultLayerIndex));
 			return resultLayerIndex;
 		}
 
@@ -6716,7 +6716,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalVector intValue = Internal.Lib3MFWrapper.convertStructToInternal_Vector (AValue);
 
-			CheckError(Internal.Lib3MFWrapper.ConstVecNode_SetVector (Handle, intValue));
+			CheckError(Internal.Lib3MFWrapper.ConstVecNode_SetVector (Handle, ref intValue));
 		}
 
 		public sVector GetVector ()
@@ -6747,7 +6747,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalMatrix4x4 intValue = Internal.Lib3MFWrapper.convertStructToInternal_Matrix4x4 (AValue);
 
-			CheckError(Internal.Lib3MFWrapper.ConstMatNode_SetMatrix (Handle, intValue));
+			CheckError(Internal.Lib3MFWrapper.ConstMatNode_SetMatrix (Handle, ref intValue));
 		}
 
 		public sMatrix4x4 GetMatrix ()
@@ -7782,7 +7782,7 @@ namespace Lib3MF {
 		{
 			Internal.InternalTransform intTransform = Internal.Lib3MFWrapper.convertStructToInternal_Transform (ATransform);
 
-			CheckError(Internal.Lib3MFWrapper.BuildItem_SetObjectTransform (Handle, intTransform));
+			CheckError(Internal.Lib3MFWrapper.BuildItem_SetObjectTransform (Handle, ref intTransform));
 		}
 
 		public String GetPartNumber ()
@@ -8955,7 +8955,7 @@ namespace Lib3MF {
 			Internal.InternalTransform intTransform = Internal.Lib3MFWrapper.convertStructToInternal_Transform (ATransform);
 			IntPtr newBuildItemInstance = IntPtr.Zero;
 
-			CheckError(Internal.Lib3MFWrapper.Model_AddBuildItem (Handle, AObjectHandle, intTransform, out newBuildItemInstance));
+			CheckError(Internal.Lib3MFWrapper.Model_AddBuildItem (Handle, AObjectHandle, ref intTransform, out newBuildItemInstance));
 			return Internal.Lib3MFWrapper.PolymorphicFactory<CBuildItem>(newBuildItemInstance);
 		}
 
@@ -9292,14 +9292,14 @@ namespace Lib3MF {
 		{
 			Internal.InternalColor intTheColor = Internal.Lib3MFWrapper.convertStructToInternal_Color (ATheColor);
 
-			CheckError(Internal.Lib3MFWrapper.ColorToRGBA (intTheColor, out ARed, out AGreen, out ABlue, out AAlpha));
+			CheckError(Internal.Lib3MFWrapper.ColorToRGBA (ref intTheColor, out ARed, out AGreen, out ABlue, out AAlpha));
 		}
 
 		public static void ColorToFloatRGBA (sColor ATheColor, out Single ARed, out Single AGreen, out Single ABlue, out Single AAlpha)
 		{
 			Internal.InternalColor intTheColor = Internal.Lib3MFWrapper.convertStructToInternal_Color (ATheColor);
 
-			CheckError(Internal.Lib3MFWrapper.ColorToFloatRGBA (intTheColor, out ARed, out AGreen, out ABlue, out AAlpha));
+			CheckError(Internal.Lib3MFWrapper.ColorToFloatRGBA (ref intTheColor, out ARed, out AGreen, out ABlue, out AAlpha));
 		}
 
 		public static sTransform GetIdentityTransform ()


### PR DESCRIPTION
https://github.com/3MFConsortium/lib3mf/issues/284

When passing user-defined struct from CSharp bindings to C++, ref should be used to receive them as pointers in implementation side, if its not used it should be received as Value.

This is a direct patch, in the next release updating of ACT will resolve this issue. 