### PR TITLE
Add include for std::find()

### DIFF
--- a/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp
+++ b/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp
@@ -32,6 +32,8 @@ sorting them topologically.
 
 #include "Model/Writer/v100/NMR_ResourceDependencySorter.h"
 
+#include <algorithm>
+
 #include "Common/Graph/DirectedGraph.h"
 #include "Common/Graph/GraphAlgorithms.h"
 #include "Model/Classes/NMR_Model.h"


### PR DESCRIPTION
When building OpenSCAD with lib3mf-v2.4.1 as dependency on flathub, I'm getting a compile error:

-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0

```
[316/344] Building CXX object CMakeFiles/lib3mf.dir/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp.o
FAILED: CMakeFiles/lib3mf.dir/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp.o 
/usr/bin/c++ -DBUILD_DLL -DFASTFLOAT_ALLOWS_LEADING_PLUS=1 -DGUID_CUSTOM -Dlib3mf_EXPORTS -I/run/build/lib3mf/Libraries/cpp-base64/Include -I/run/build/lib3mf/Libraries/fast_float/Include -I/run/build/lib3mf/Libraries/googletest/Include -I/run/build/lib3mf/Autogenerated/Source -I/run/build/lib3mf/Include/API -I/run/build/lib3mf/Include -I/run/build/lib3mf/submodules/fast_float/include -O2 -pipe -g -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -std=c++17 -O2 -O2 -g -DNDEBUG -std=gnu++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -D__LIB3MF_EXPORTS -MD -MT CMakeFiles/lib3mf.dir/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp.o -MF CMakeFiles/lib3mf.dir/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp.o.d -o CMakeFiles/lib3mf.dir/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp.o -c /run/build/lib3mf/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp
/run/build/lib3mf/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp: In member function ‘NMR::TopologicalSortResult NMR::CResourceDependencySorter::sort()’:
/run/build/lib3mf/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp:77:22: error: ‘find’ is not a member of ‘std’; did you mean ‘bind’?
   77 |             if (std::find(sortedResources.begin(), sortedResources.end(), modelResourceID) == sortedResources.end()) {
      |                      ^~~~
      |                      bind
```
Adding the required include [`<algorithm>`](https://en.cppreference.com/w/cpp/header/algorithm) for [`std::find()`](https://en.cppreference.com/w/cpp/algorithm/find) fixes the issue for me.