### PR TITLE
Bump cmake_minimum_required to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.5)
 
 cmake_policy(SET CMP0054 NEW)
 cmake_policy(SET CMP0048 NEW)

--- a/SDK/Examples/Cpp/CMakeLists.txt
+++ b/SDK/Examples/Cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.5)
 
 set(CMAKE_CXX_STANDARD 17)
 


### PR DESCRIPTION
CMake 4.0 has dropped support for older versions, and fails to build. GHA's runners have now been (partially) updated to use CMake 4.0, causing the builds to fail.

But perhaps there is a good reason why this old cmake version is specified?