### PR TITLE
Update CMakeLists.txt to support CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.5)
 
 cmake_policy(SET CMP0054 NEW)
 cmake_policy(SET CMP0048 NEW)


### PR DESCRIPTION
CMake 4 is now released and is the default on e.g. Homebrew. In version 4, CMake deprecated support for CMake < 3.5, so I'm bumping the minimum required version to 3.5. CMake 3.5 is ancient, so no issues are found or expected.