### PR TITLE
Fix compile errors for gcc-14 on Debian trixie

### DIFF
--- a/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp
+++ b/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp
@@ -37,6 +37,8 @@ sorting them topologically.
 #include "Model/Classes/NMR_Model.h"
 #include "Model/Classes/NMR_ModelResource.h"
 
+#include <algorithm>
+
 namespace NMR
 {
 

--- a/Tests/CPP_Bindings/Source/Volumetric.cpp
+++ b/Tests/CPP_Bindings/Source/Volumetric.cpp
@@ -33,6 +33,8 @@ Vulometric.cpp: Defines Unittests for the Volumetric extension
 #include "UnitTest_Utilities.h"
 #include "lib3mf_implicit.hpp"
 
+#include <algorithm>
+
 namespace Lib3MF
 {
     namespace helper


### PR DESCRIPTION
Currently it is not possible to build lib3mf master on Debian Trixie with gcc 14. This is because  inclusion of `<algorithm>` is needed in order to use std::find, but it was missing, leading to the compiler error.

This pull request fixes this issue.