### PR TITLE
updating windows version from 2019 to 2022 github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,7 +189,7 @@ jobs:
           verbose: true # optional (default = false)
           
   build-windows-release:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [set-lib3mf-version]
     env:
       LIB3MF_VERSION: ${{ needs.set-lib3mf-version.outputs.lib3mf-version }}
@@ -226,7 +226,7 @@ jobs:
           path: build/${{ env.ARTIFACT_NAME }}
 
   build-windows-debug:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [set-lib3mf-version]
     steps:
       - uses: actions/checkout@v4
@@ -251,7 +251,7 @@ jobs:
           name: lib3mf.debug.lib
           path: build/Debug/lib3mf.lib
   build-windows-32bit:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [set-lib3mf-version]
     steps:
       - uses: actions/checkout@v4
@@ -273,7 +273,7 @@ jobs:
           name: lib3mf_32bit.lib
           path: build_32bit/Release/lib3mf.lib
   build-mingw-w64:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [set-lib3mf-version]
     steps:
       - run: choco install mingw -y
@@ -410,7 +410,7 @@ jobs:
           ./create_cube
 
   deploy-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [set-lib3mf-version, assemble-sdk]
     env:
       LIB3MF_VERSION: ${{ needs.set-lib3mf-version.outputs.lib3mf-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: ./cmake/GenerateVS2019.bat
+      - run: ./cmake/GenerateVS2022.bat
       - run: cmake --build . --config Release
         working-directory: ./build
       - run: ctest -V
@@ -232,7 +232,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: ./cmake/GenerateVS2019.bat
+      - run: ./cmake/GenerateVS2022.bat
       - run: cmake --build . --config Debug
         working-directory: ./build
       - run: ctest -V
@@ -425,13 +425,13 @@ jobs:
           unzip lib3mf_sdk.zip/lib3mf_sdk.zip
       - name: Build CppDynamic
         run: |
-          ./Examples/CppDynamic/GenerateVS2019.bat
+          ./Examples/CppDynamic/GenerateVS2022.bat
           cd Examples/CppDynamic/build
           cmake --build . --config Release
           ./Release/Example_ExtractInfo.exe ../../Files/Helix.3mf
       - name: Build Cpp
         run: |
-          ./Examples/Cpp/GenerateVS2019.bat
+          ./Examples/Cpp/GenerateVS2022.bat
           cd Examples/Cpp/build
           cmake --build . --config Release
           ./Release/Example_ExtractInfo.exe ../../Files/Helix.3mf
@@ -452,13 +452,13 @@ jobs:
           unzip lib3mf-${{ env.LIB3MF_VERSION }}-Windows.zip/lib3mf-${{ env.LIB3MF_VERSION }}-Windows.zip
       - name: Build CppDynamic - CPack (Windows)
         run: | 
-          ./SDK/CPackExamples/CppDynamic/GenerateVS2019.bat
+          ./SDK/CPackExamples/CppDynamic/GenerateVS2022.bat
           cd SDK/CPackExamples/CppDynamic/build
           cmake --build . --config Release
           ./Release/Example_ExtractInfo.exe ../../../Examples/Files/Helix.3mf
       - name: Build Cpp - CPack (Windows)
         run: |
-          ./SDK/CPackExamples/Cpp/GenerateVS2019.bat
+          ./SDK/CPackExamples/Cpp/GenerateVS2022.bat
           cd SDK/CPackExamples/Cpp/build
           cmake --build . --config Release
           ./Release/Example_ExtractInfo.exe ../../../Examples/Files/Helix.3mf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: ./cmake/GenerateVS2019_32bit.bat
+      - run: ./cmake/GenerateVS2022_32bit.bat
       - run: cmake --build . --config Release
         working-directory: ./build_32bit
       - run: ctest -V

--- a/SDK/CPackExamples/Cpp/GenerateVS2022.bat
+++ b/SDK/CPackExamples/Cpp/GenerateVS2022.bat
@@ -1,0 +1,10 @@
+@echo off
+set startingDir=%CD%
+
+set basepath=%~dp0
+set builddir=%basepath%\build
+if not exist %builddir% (mkdir %builddir%)
+cd %builddir%
+cmake -G "Visual Studio 17 2022" .. %*
+
+cd %startingDir%

--- a/SDK/CPackExamples/CppDynamic/GenerateVS2022.bat
+++ b/SDK/CPackExamples/CppDynamic/GenerateVS2022.bat
@@ -1,0 +1,10 @@
+@echo off
+set startingDir=%CD%
+
+set basepath=%~dp0
+set builddir=%basepath%\build
+if not exist %builddir% (mkdir %builddir%)
+cd %builddir%
+cmake -G "Visual Studio 17 2022" .. %*
+
+cd %startingDir%

--- a/SDK/Examples/Cpp/GenerateVS2022.bat
+++ b/SDK/Examples/Cpp/GenerateVS2022.bat
@@ -1,0 +1,10 @@
+@echo off
+set startingDir=%CD%
+
+set basepath=%~dp0
+set builddir=%basepath%\build
+if not exist %builddir% (mkdir %builddir%)
+cd %builddir%
+cmake -G "Visual Studio 17 2022" .. %*
+
+cd %startingDir%

--- a/SDK/Examples/CppDynamic/GenerateVS2022.bat
+++ b/SDK/Examples/CppDynamic/GenerateVS2022.bat
@@ -1,0 +1,10 @@
+@echo off
+set startingDir=%CD%
+
+set basepath=%~dp0
+set builddir=%basepath%\build
+if not exist %builddir% (mkdir %builddir%)
+cd %builddir%
+cmake -G "Visual Studio 17 2022" .. %*
+
+cd %startingDir%

--- a/cmake/GenerateVS2022_32bit.bat
+++ b/cmake/GenerateVS2022_32bit.bat
@@ -1,0 +1,10 @@
+@echo off
+set startingDir="%CD%"
+
+set basepath="%~dp0"
+set builddir=%basepath%\..\build_32bit
+if not exist %builddir% (mkdir %builddir%)
+cd %builddir%
+cmake -G "Visual Studio 17 2022" -A Win32 .. %*
+
+cd %startingDir%


### PR DESCRIPTION
The Windows 2019 Actions runner image will begin deprecation on 2025-06-01 and will be fully unsupported by 2025-06-30