### PR TITLE
Test/Volumetric: fix missing algorithm include

### DIFF
--- a/Tests/CPP_Bindings/Source/Volumetric.cpp
+++ b/Tests/CPP_Bindings/Source/Volumetric.cpp
@@ -33,6 +33,8 @@ Vulometric.cpp: Defines Unittests for the Volumetric extension
 #include "UnitTest_Utilities.h"
 #include "lib3mf_implicit.hpp"
 
+#include <algorithm>
+
 namespace Lib3MF
 {
     namespace helper


### PR DESCRIPTION
analogous to #413

found while updating the nix package to 2.4.1. Causes tests to fail to build. While we could technically just disable the tests, fixing the issue is preferable.