### PR TITLE
CMake: fix include dir in export

### DIFF
--- a/cmake/lib3mfConfig.cmake
+++ b/cmake/lib3mfConfig.cmake
@@ -22,7 +22,7 @@ foreach(comp ${lib3mf_FIND_COMPONENTS})
 endforeach()
 
 # Configure paths based on the selected variant
-set(lib3mf_INCLUDE_DIR "${LIB3MF_ROOT_DIR}/include/Bindings/${lib3mf_selected_variant}")
+set(lib3mf_INCLUDE_DIR "${LIB3MF_ROOT_DIR}/include/lib3mf/Bindings/${lib3mf_selected_variant}")
 set(lib3mf_LIBRARY_DIR "${LIB3MF_ROOT_DIR}/lib")
 set(lib3mf_BINARY_DIR "${LIB3MF_ROOT_DIR}/bin")
 


### PR DESCRIPTION
Hi,

In nixpkgs, we are using lib3mf CMake exports in meshlab, and  without a proper `lib3mf_INCLUDE_DIR`, we get:
```
meshlab> /build/source/src/meshlabplugins/io_3mf/io_3mf.cpp:30:10: fatal error: lib3mf_implicit.hpp: No such file or directory
meshlab>    30 | #include "lib3mf_implicit.hpp"
meshlab>       |          ^~~~~~~~~~~~~~~~~~~~~
```

This is because all headers are installed in `CMAKE_INSTALL_INCLUDEDIR`, which is defined in the main `CMakeLists.txt` as:

```cmake
set(CMAKE_INSTALL_INCLUDEDIR include/lib3mf CACHE PATH "directory for installing header files")
```

ref. https://github.com/NixOS/nixpkgs/pull/445078 & https://github.com/cnr-isti-vclab/meshlab/pull/1617