### PR TITLE
fix: FTBFS with recent gcc versions

### DIFF
--- a/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp
+++ b/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp
@@ -37,6 +37,8 @@ sorting them topologically.
 #include "Model/Classes/NMR_Model.h"
 #include "Model/Classes/NMR_ModelResource.h"
 
+#include <algorithm>
+
 namespace NMR
 {
 


### PR DESCRIPTION
When compiling, gcc throws an error about missing header for std::find()